### PR TITLE
Add CodeQL code scanning and Copilot custom instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,19 @@
+# GitHub Copilot Instructions
+
+Review changes as a **senior TypeScript engineer** specializing in **GitHub Actions** and **LLM API integrations**, focusing on production-grade code quality, security isolation, and maintainable modular architecture.
+
+## Project Context
+
+Codex Code Review Action is a GitHub Action that performs AI-powered code review using OpenAI Codex. It uses a two-job design with security isolation: a read-only review job (diff chunking, prompt assembly, structured findings) and a write-access publish job (inline PR comments, per-file summaries, verdict).
+
+- Runtime: Node 22, TypeScript, bundled with esbuild
+- Dependencies: @actions/core, @actions/github, openai
+- Architecture: modular src/ with separated concerns (core, github, openai, config)
+
+## Review Focus Areas
+
+1. **Security** — secrets handling, input validation, permission scoping, job isolation between read-only and write-access jobs
+2. **Type safety** — no `any`, no unsafe assertions, proper error typing
+3. **Error resilience** — retry logic, rate limiting, graceful degradation for external API calls (OpenAI, GitHub)
+4. **Modularity** — clear boundaries, constructor injection, single responsibility, low coupling
+5. **Action correctness** — proper use of @actions/core and @actions/github APIs, input/output handling, secret masking

--- a/.github/instructions/code-review.instructions.md
+++ b/.github/instructions/code-review.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: "**/*"
+---
+
+# Code Review Philosophy
+
+## Approach
+
+- Be constructive and opinionated — flag code smells, not just bugs
+- Suggest better patterns, not just what is wrong
+- Simpler is better — challenge unnecessary complexity
+- Challenge abstractions that are not earning their keep
+- Acknowledge good patterns when encountered
+
+## Severity Levels
+
+- **Critical**: security vulnerabilities, data loss, authentication bypass — blocks merge
+- **High**: unhandled exceptions, performance regressions, logic errors
+- **Medium**: code smells, missing error handling, suboptimal patterns
+- **Low**: style inconsistencies, naming improvements, minor refactors
+
+Only block merges on critical findings. Surface critical and high in the summary.
+
+## Structured Findings
+
+Each finding should include:
+- **File and line** where the issue occurs
+- **Severity** level (critical, high, medium, low)
+- **Description** of the problem and why it matters
+- **Suggestion** with a concrete fix or alternative
+
+## What to Look For
+
+- Security: injection, secrets exposure, unsafe input handling, missing validation
+- Error handling: swallowed errors, missing catch blocks, unhandled rejections
+- Performance: unnecessary allocations, redundant operations, N+1 patterns
+- Architecture: tight coupling, single responsibility violations, missing boundaries
+- Types: incorrect types, unsafe assertions, missing null checks
+- Edge cases: empty inputs, boundary values, concurrent access
+
+## Noise Reduction
+
+- Do not flag auto-generated code or migration files
+- Do not flag style issues already covered by linters
+- Focus on logic and architecture over formatting
+- One finding per issue — do not repeat the same concern across files

--- a/.github/instructions/json.instructions.md
+++ b/.github/instructions/json.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "**/*.json"
+---
+
+# JSON Conventions
+
+- All keys must be sorted alphabetically at every nesting level
+- Use 2-space indentation
+- Pin dependency versions exactly (no `^` or `~` prefixes)
+- `package-lock.json` must be committed for reproducible builds

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -1,0 +1,48 @@
+---
+applyTo: "**/*"
+---
+
+# Project Context
+
+This is a TypeScript GitHub Action for AI-powered code review using OpenAI Codex.
+
+## Architecture
+
+- Two-job design with security isolation:
+  - **Review job** (read-only): diff chunking, prompt assembly, structured findings
+  - **Publish job** (write-access): inline PR comments, per-file summaries, verdict
+- Bundled with `esbuild` into a single `dist/main.js`
+- Runs on Node 22 (`node22` GitHub Actions runtime)
+
+## Module Structure
+
+```
+src/
+├── core/          # Pure business logic (review engine, diff processing)
+├── github/        # GitHub API interaction (read context, post comments)
+├── openai/        # OpenAI API integration (prompts, retry, rate limiting)
+├── config/        # Configuration constants and defaults
+└── main.ts        # Entry point and orchestration
+```
+
+## Build and Validation
+
+- Build: `npm run build`
+- Type check: `npm run typecheck`
+- Test: `npm test`
+
+## Conventions
+
+- Exact dependency versions in `package.json` (no caret or tilde ranges)
+- `.yaml` extension for all YAML files
+- Modular design: small, composable modules with clear boundaries
+- Extract modules when it reduces complexity, not just to split files
+- Keep coupling low and cohesion high
+
+## Security Model
+
+- Set minimal `permissions` in workflows (only what the job needs)
+- Mask secrets with `core.setSecret()` before any logging
+- Pass untrusted input via environment variables, never interpolate into shell commands
+- Validate all external inputs at system boundaries
+- Pin third-party actions to full commit SHA

--- a/.github/instructions/typescript.instructions.md
+++ b/.github/instructions/typescript.instructions.md
@@ -1,0 +1,84 @@
+---
+applyTo: "**/*.ts"
+---
+
+# TypeScript Standards
+
+## Type Safety
+
+- Strict TypeScript — no `any`, no type assertions unless unavoidable with justification
+- Use `unknown` over `any` when the type is truly unknown
+- Prefer type inference where obvious, explicit annotations at function boundaries
+- Define interfaces for API responses, never pass raw untyped data
+
+```typescript
+// Preferred
+function processFindings(findings: readonly Finding[]): Summary {
+
+// Avoided
+function processFindings(findings: any): any {
+```
+
+## Error Handling
+
+- Top-level: catch with `core.setFailed()` for clean Action failure reporting
+- Use typed error checking with `instanceof Error`
+- No swallowed errors, no empty catch blocks
+- Validate inputs at system boundaries, trust internal code
+
+```typescript
+// Preferred
+async function run(): Promise<void> {
+  try {
+    const token = core.getInput("github-token", { required: true });
+    core.setSecret(token);
+    // ...
+  } catch (error) {
+    core.setFailed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+// Avoided
+async function run(): Promise<void> {
+  const token = core.getInput("github-token");
+  // unhandled rejection if anything throws
+}
+```
+
+## Async Patterns
+
+- Always `await` promises — never fire-and-forget
+- Use `async`/`await` over raw `.then()` chains
+- Implement exponential backoff with jitter for external API calls
+
+## Code Quality
+
+- Pure functions over side effects
+- Small, focused functions with single responsibility
+- Prefer `const` over `let`, never `var`
+- No magic numbers or strings — use named constants
+- Meaningful names — no abbreviations, no single-letter variables outside loops
+- No dead code, no commented-out code, no TODOs without linked issues
+
+## Modularity
+
+- Small, composable modules with clear boundaries
+- Separate concerns: I/O, business logic, and data transformation
+- Constructor injection for dependencies — no DI containers
+
+```typescript
+// Preferred — injectable, testable
+class ReviewEngine {
+  constructor(
+    private readonly aiClient: AIClient,
+    private readonly diffProcessor: DiffProcessor,
+  ) {}
+}
+
+// Avoided — hard-coded, untestable
+class ReviewEngine {
+  private readonly aiClient = new OpenAIClient(process.env.API_KEY!);
+}
+```
+
+- Keep modules focused — if a module does too many things, split it

--- a/.github/instructions/yaml.instructions.md
+++ b/.github/instructions/yaml.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "**/*.yaml"
+---
+
+# YAML Conventions
+
+- Use `.yaml` extension, not `.yml`
+- Use 2-space indentation
+- Quote string values that could be misinterpreted (booleans, numbers)
+- Pin GitHub Actions to full commit SHA for security

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,29 @@
+name: "CodeQL Code Scanning"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  analyze:
+    name: CodeQL TypeScript Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "name": "codex-code-review-action",
   "private": true,
   "scripts": {
-    "build": "esbuild src/main.ts --bundle --minify --outfile=dist/main.js --platform=node --target=node22"
+    "build": "esbuild src/main.ts --bundle --minify --outfile=dist/main.js --platform=node --target=node22",
+    "typecheck": "tsc --noEmit"
   },
   "version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Add CodeQL code scanning workflow for TypeScript security analysis
- Add Copilot global instructions defining reviewer authority and project context
- Add 5 targeted instruction files for TypeScript, JSON, YAML, code review, and project conventions
- Add `typecheck` script to `package.json`

## Details
- **CodeQL:** runs on push to main and PRs, scans `javascript-typescript`, all actions pinned to commit SHA
- **Copilot instructions:** separated by concern with `applyTo` frontmatter for targeted guidance
  - `project.instructions.md` — architecture, build commands, security model
  - `typescript.instructions.md` — type safety, error handling, modularity with code examples
  - `code-review.instructions.md` — severity levels, structured findings, noise reduction
  - `json.instructions.md` — alphabetical keys, exact versions
  - `yaml.instructions.md` — `.yaml` extension, SHA pinning