### PR TITLE
Fix coverage badge script failing on redundant mv command

### DIFF
--- a/.github/scripts/update-coverage-badge.sh
+++ b/.github/scripts/update-coverage-badge.sh
@@ -46,7 +46,6 @@ git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
 git checkout --orphan badges
 git rm -rf .
-mv coverage.json .
 git add coverage.json
 git commit -m "Update coverage badge to ${TOTAL}% [skip ci]"
 git push origin badges --force


### PR DESCRIPTION
## Summary

- Remove redundant `mv coverage.json .` in the badge update script that fails because source and destination are the same file
- The script creates `coverage.json` in the working directory via heredoc, then `git rm -rf .` only removes tracked files — so the file is already in place when `git add` runs

## Root cause

The `update-badge` job ([logs](https://github.com/milanhorvatovic/codex-code-review-action/actions/runs/24010882717/job/70022212998)) fails with:

```
mv: 'coverage.json' and './coverage.json' are the same file
```

`cat > coverage.json` writes to the current directory. After `git checkout --orphan badges && git rm -rf .`, untracked files (including `coverage.json`) remain in place. The `mv coverage.json .` is a no-op that errors out under `set -e`.