### PR TITLE
Update action branding colors and review icon

### DIFF
--- a/publish/action.yaml
+++ b/publish/action.yaml
@@ -2,7 +2,7 @@ name: "Codex Review — Publish"
 description: "Validate and publish Codex review as a GitHub PR review with inline comments (write-access job). Requires .codex/ artifacts from the review action."
 
 branding:
-  color: "purple"
+  color: "green"
   icon: "message-square"
 
 inputs:

--- a/review/action.yaml
+++ b/review/action.yaml
@@ -2,8 +2,8 @@ name: "Codex Review — Review"
 description: "Prepare diff, split into chunks, and run Codex review (read-only job). Produces .codex/ artifacts for the publish action."
 
 branding:
-  color: "purple"
-  icon: "eye"
+  color: "blue"
+  icon: "search"
 
 inputs:
   allowed-users:


### PR DESCRIPTION
## Summary

- Change review action branding from purple/eye to blue/search — better represents code analysis
- Change publish action branding from purple to green — better represents posting results/verdict