### PR TITLE
Add root action.yaml stub for GitHub Marketplace listing

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -10,5 +10,5 @@ runs:
   steps:
     - shell: bash
       run: |
-        echo "::error::The path 'milanhorvatovic/codex-review-action' is not a valid action. Please use 'milanhorvatovic/codex-review-action/review' and 'milanhorvatovic/codex-review-action/publish' instead. See the README for usage instructions."
+        echo "::error::Do not use 'milanhorvatovic/codex-code-review-action' directly. Please use 'milanhorvatovic/codex-code-review-action/review' and 'milanhorvatovic/codex-code-review-action/publish' instead. See the README for usage instructions."
         exit 1


### PR DESCRIPTION
## Summary

- Add root `action.yaml` as a composite stub for GitHub Marketplace listing eligibility
- Uses `::error::` annotation to direct users to the `review` and `publish` sub-actions
- Follows the established pattern used by `gradle/actions` and `github/codeql-action`