### PR TITLE
Shorten root action description to meet Marketplace limit

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: "Codex Review"
-description: "AI-powered code review GitHub Action using OpenAI Codex. Use the review and publish sub-actions — see the documentation for details."
+description: "AI-powered code review using OpenAI Codex. Use the review and publish sub-actions."
 
 branding:
   color: "blue"


### PR DESCRIPTION
## Summary

- Shorten root `action.yaml` description to under 125 characters as required by GitHub Marketplace