### PR TITLE
Add changelog entry for v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-04-06
+
+### Fixed
+
+- Action runtime updated from `node22` to `node24` — `node22` is not supported by GitHub Actions runners
+- Node version aligned to 24.14.1 across build target, CI workflows, and local tooling
+
 ## [1.0.3] - 2026-04-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-ai-code-review-action",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-ai-code-review-action",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "6.2.1",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
-  "version": "1.0.3"
+  "version": "1.0.4"
 }


### PR DESCRIPTION
## Summary

- Bump version to 1.0.4
- Add changelog entry for the node22 → node24 runtime fix

Closes #21