### PR TITLE
Prepare v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2026-04-06
+## [2.0.0] - 2026-04-07
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,10 @@ npm run lint         # Lint source code
 npm run typecheck    # Type check
 ```
 
+## Version history
+
+See the [`CHANGELOG`](CHANGELOG.md) for details.
+
 ## License
 
 This project is licensed under the [MIT](LICENSE).


### PR DESCRIPTION
## Summary

- Fix v2.0.0 changelog date from `2026-04-06` to `2026-04-07` to match actual commit date
- Add "Version history" section to README linking to CHANGELOG

## Next steps

After merging, tag `v2.0.0` on main to trigger the release workflow.