### PR TITLE
chore: rebuild dist on Dependabot PRs to prevent stale-bundle build failures

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -9,7 +9,9 @@ permissions:
 
 jobs:
   rebuild-dist:
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,8 +27,11 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
+
+      - name: Disable git hooks
+        run: git config --local core.hooksPath /dev/null
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -55,7 +60,9 @@ jobs:
           git push "https://x-access-token:${REBUILD_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
 
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     needs: rebuild-dist
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -14,10 +14,19 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Verify rebuild token is configured
+        env:
+          REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
+        run: |
+          if [ -z "$REBUILD_TOKEN" ]; then
+            echo "::error::Repo secret DEPENDABOT_REBUILD_TOKEN is missing. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          token: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -30,6 +39,10 @@ jobs:
         run: npm run build
 
       - name: Commit and push dist if changed
+        env:
+          REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          REPO: ${{ github.repository }}
         run: |
           if [ -z "$(git status --porcelain dist/)" ]; then
             echo "dist/ is already up to date; nothing to commit."
@@ -39,7 +52,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
           git commit -m "chore: rebuild dist after dependency update"
-          git push
+          git push "https://x-access-token:${REBUILD_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
 
   auto-merge:
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -8,8 +8,42 @@ permissions:
   pull-requests: read
 
 jobs:
+  rebuild-dist:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          cache: "npm"
+          node-version: "24.14.1"
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Commit and push dist if changed
+        run: |
+          if [ -z "$(git status --porcelain dist/)" ]; then
+            echo "dist/ is already up to date; nothing to commit."
+            exit 0
+          fi
+          git config user.name "dependabot[bot]"
+          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "chore: rebuild dist after dependency update"
+          git push
+
   auto-merge:
     if: github.actor == 'dependabot[bot]'
+    needs: rebuild-dist
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -35,8 +35,8 @@ jobs:
             echo "dist/ is already up to date; nothing to commit."
             exit 0
           fi
-          git config user.name "dependabot[bot]"
-          git config user.email "49699333+dependabot[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
           git commit -m "chore: rebuild dist after dependency update"
           git push


### PR DESCRIPTION
## Summary

- Add a `rebuild-dist` job to `.github/workflows/dependabot-auto-merge.yaml` that runs `npm ci && npm run build` on every Dependabot PR and pushes the regenerated `dist/` back to the PR branch when it has drifted.
- Make the `auto-merge` job depend on `rebuild-dist` so auto-merge is enabled only after the bundle has been refreshed (or confirmed up to date).
- Use a fine-grained PAT (`DEPENDABOT_REBUILD_TOKEN`) for the rebuild push so the new commit re-triggers `tests.yaml` — pushes made with the default `GITHUB_TOKEN` do not trigger downstream workflows.

Closes #47.

## Why

Dependabot only edits `package.json` / `package-lock.json` and never re-runs `npm run build`. Whenever a *runtime* dep changes, the committed `dist/` drifts from what `npm run build` produces, and the `build` job in `tests.yaml` fails on `git diff --exit-code dist/`. Recent examples: #34 (`fast-xml-parser`), #31 (`@actions/github`).

## Required setup before merging

A repo secret named **`DEPENDABOT_REBUILD_TOKEN`** must be created with a fine-grained PAT that has, for this repo only:

- `Contents: Read and write`
- `Pull requests: Read and write`

Without this secret, the `rebuild-dist` job will fail at checkout and `auto-merge` will not run — leaving the PR in the same broken state we already have today, so this is fail-closed.

## Token decision (recap from #47)

Picked **fine-grained PAT (Option A)** over GitHub App (overkill for a single-maintainer personal repo) and over post-merge rebuild on `main` (would leave a window of stale `dist/` on `main`, which is a correctness regression for a SHA-pinned action).

## Out of scope

PRs #34 and #31 still need their `dist/` rebuilt manually before they can merge — this workflow only helps **future** Dependabot PRs.

## Test plan

- [x] Create `DEPENDABOT_REBUILD_TOKEN` secret in repo settings.
