### PR TITLE
Only require DEPENDABOT_REBUILD_TOKEN when rebuild-dist actually pushes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -16,15 +16,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Verify rebuild token is configured
-        env:
-          REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
-        run: |
-          if [ -z "$REBUILD_TOKEN" ]; then
-            echo "::error::Repo secret DEPENDABOT_REBUILD_TOKEN is missing. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Actions."
-            exit 1
-          fi
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -52,6 +43,10 @@ jobs:
           if [ -z "$(git status --porcelain dist/)" ]; then
             echo "dist/ is already up to date; nothing to commit."
             exit 0
+          fi
+          if [ -z "$REBUILD_TOKEN" ]; then
+            echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
+            exit 1
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary
- Move the `dist/` diff check ahead of the token-presence check inside the existing "Commit and push dist if changed" step.
- Remove the standalone `Verify rebuild token is configured` step — the token only matters if a push will happen.
- Updated the error message to point at the **Dependabot** secret store (the one the workflow actually reads in its primary context).

After this change, `DEPENDABOT_REBUILD_TOKEN` only needs to live in the Dependabot secret store. The synchronize-event run that fires after a rebuild push finds no `dist/` diff and exits cleanly without ever reading the secret, so we no longer need to mirror it into the Actions store to satisfy a guard on a no-op run.

Fixes #50.

## Background

When a Dependabot PR's dependency update changes `dist/`, one PR's lifecycle spans two workflow runs in different secret contexts:

1. PR opened by Dependabot — `pull_request` event, triggering actor `dependabot[bot]` → **Dependabot** secret store.
2. `rebuild-dist` pushes the regenerated `dist/` — `pull_request: synchronize` event, triggering actor is the PAT owner → **Actions** secret store.

The previous structure put the token guard at step 1 of `rebuild-dist`, which forced both runs to require the secret even though only the first one ever pushes. That meant the secret had to live in both stores. Reordering removes that artificial requirement.

## Test plan
- [ ] Merge an existing Dependabot PR whose dependency change does *not* affect `dist/` (e.g. dev-deps, github-actions group); confirm `rebuild-dist` exits cleanly with "dist/ is already up to date".
- [ ] Merge an existing Dependabot PR whose dependency change *does* affect `dist/` (production deps that get bundled); confirm `rebuild-dist` regenerates and pushes, the follow-up synchronize run no-ops, and `auto-merge` proceeds.
- [ ] After this lands, the Actions-store copy of `DEPENDABOT_REBUILD_TOKEN` (if previously mirrored) can be safely removed.