### PR TITLE
Sign rebuild-dist commits with a dedicated GPG subkey

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -24,16 +24,6 @@ jobs:
       - name: Disable git hooks
         run: git config --local core.hooksPath /dev/null
 
-      - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
-        with:
-          gpg_private_key: ${{ secrets.DEPENDABOT_GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_config_global: true
-          git_committer_name: ${{ vars.DEPENDABOT_GIT_COMMITTER_NAME }}
-          git_committer_email: ${{ vars.DEPENDABOT_GIT_COMMITTER_EMAIL }}
-
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: "npm"
@@ -44,16 +34,34 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Commit and push dist if changed
+      - name: Detect dist changes
+        id: dist
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "dist/ is already up to date; nothing to commit."
+          fi
+
+      - name: Import GPG key
+        if: steps.dist.outputs.changed == 'true'
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.DEPENDABOT_GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: ${{ vars.DEPENDABOT_GIT_COMMITTER_NAME }}
+          git_committer_email: ${{ vars.DEPENDABOT_GIT_COMMITTER_EMAIL }}
+
+      - name: Commit and push dist
+        if: steps.dist.outputs.changed == 'true'
         env:
           REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
         run: |
-          if [ -z "$(git status --porcelain dist/)" ]; then
-            echo "dist/ is already up to date; nothing to commit."
-            exit 0
-          fi
           if [ -z "$REBUILD_TOKEN" ]; then
             echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
             exit 1

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           missing=0
           if [ -z "$REBUILD_TOKEN" ]; then
-            echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
+            echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
             missing=1
           fi
           if [ -z "$GPG_PRIVATE_KEY" ]; then

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -24,6 +24,16 @@ jobs:
       - name: Disable git hooks
         run: git config --local core.hooksPath /dev/null
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        with:
+          gpg_private_key: ${{ secrets.DEPENDABOT_GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_config_global: true
+          git_committer_name: ${{ vars.DEPENDABOT_GIT_COMMITTER_NAME }}
+          git_committer_email: ${{ vars.DEPENDABOT_GIT_COMMITTER_EMAIL }}
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           cache: "npm"
@@ -48,8 +58,6 @@ jobs:
             echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
             exit 1
           fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
           git commit -m "chore: rebuild dist after dependency update"
           git push "https://x-access-token:${REBUILD_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -44,6 +44,35 @@ jobs:
             echo "dist/ is already up to date; nothing to commit."
           fi
 
+      - name: Validate rebuild-dist configuration
+        if: steps.dist.outputs.changed == 'true'
+        env:
+          REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
+          GPG_PRIVATE_KEY: ${{ secrets.DEPENDABOT_GPG_PRIVATE_KEY }}
+          COMMITTER_NAME: ${{ vars.DEPENDABOT_GIT_COMMITTER_NAME }}
+          COMMITTER_EMAIL: ${{ vars.DEPENDABOT_GIT_COMMITTER_EMAIL }}
+        run: |
+          missing=0
+          if [ -z "$REBUILD_TOKEN" ]; then
+            echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
+            missing=1
+          fi
+          if [ -z "$GPG_PRIVATE_KEY" ]; then
+            echo "::error::Dependabot secret DEPENDABOT_GPG_PRIVATE_KEY is missing — required to sign the rebuilt dist/ commit so it satisfies main's required_signatures rule. Export an armored sign-only GPG subkey ('gpg --armor --export-secret-subkeys <subkey-id>!') and store it as DEPENDABOT_GPG_PRIVATE_KEY under Settings → Secrets and variables → Dependabot."
+            missing=1
+          fi
+          if [ -z "$COMMITTER_NAME" ]; then
+            echo "::error::Repo variable DEPENDABOT_GIT_COMMITTER_NAME is missing — required as the committer name for the signed rebuild-dist commit. Set it under Settings → Secrets and variables → Actions → Variables."
+            missing=1
+          fi
+          if [ -z "$COMMITTER_EMAIL" ]; then
+            echo "::error::Repo variable DEPENDABOT_GIT_COMMITTER_EMAIL is missing — required as the committer email for the signed rebuild-dist commit. It must match a UID on the imported GPG key and a verified email on the GitHub account that owns the public key. Set it under Settings → Secrets and variables → Actions → Variables."
+            missing=1
+          fi
+          if [ "$missing" -ne 0 ]; then
+            exit 1
+          fi
+
       - name: Import GPG key
         if: steps.dist.outputs.changed == 'true'
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
@@ -62,10 +91,6 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
         run: |
-          if [ -z "$REBUILD_TOKEN" ]; then
-            echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write, Pull requests: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
-            exit 1
-          fi
           git add dist/
           git commit -m "chore: rebuild dist after dependency update"
           git push "https://x-access-token:${REBUILD_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"


### PR DESCRIPTION
## Summary
- Import a sign-only GPG subkey in the `rebuild-dist` job and enable global commit signing on the runner so every `git commit` it produces is signed.
- Source committer name and email from repo variables (`vars.DEPENDABOT_GIT_COMMITTER_NAME`, `vars.DEPENDABOT_GIT_COMMITTER_EMAIL`) rather than hard-coding them, so the identity can be rotated without a workflow change.
- Drop the inline `git config user.name/user.email` from the push step — the import step handles them.
- Pin `crazy-max/ghaction-import-gpg` to a commit SHA (v7.0.0).

After this lands, Dependabot PRs whose dependency change requires a `dist/` rebuild will produce a verified, signed commit and pass `main`'s `required_signatures` rule. The previously merged Dependabot PRs (#32, #33) only worked because their changes did not require a rebuild; PRs that did need one (#34, #49) hit the unsigned-commit block.

Fixes #52.

## Required configuration before merge

The maintainer must:

1. Create a sign-only GPG subkey under their primary key, with a single UID set to a noreply email already verified on their GitHub account (e.g. `<id>+<login>@users.noreply.github.com`).
2. Upload the primary's public key (now carrying the new UID + subkey) to their GitHub account.
3. Export only the subkey's secret material with `gpg --armor --export-secret-subkeys '<subkey-id>!'`.
4. Set the following on this repo:
   - **Dependabot secret** `DEPENDABOT_GPG_PRIVATE_KEY` — the armored subkey export from step 3.
   - **Repo variable** `DEPENDABOT_GIT_COMMITTER_NAME` — the name to attribute commits to.
   - **Repo variable** `DEPENDABOT_GIT_COMMITTER_EMAIL` — the noreply email matching the UID from step 1.

The committer email must match both a UID on the imported key and a verified email on the GitHub account that owns the public key, otherwise the commit will not show as Verified.

## Why a subkey rather than the personal key

The subkey is exported in isolation (the primary key's secret material stays on the maintainer's machine as a stub on the runner). If the runner is compromised, only the subkey is exposed; the primary remains intact and the subkey can be revoked via the primary without disrupting the maintainer's other signed work.

## Why repo variables for committer identity

Variables aren't partitioned by Dependabot/Actions context the way secrets are; `vars.*` resolves correctly in Dependabot-triggered runs. Storing committer name/email as variables avoids exposing the maintainer's identity in the workflow file and lets the values be rotated (e.g., to a service-account identity) without code changes.

## Test plan

- [ ] After merge, request `@dependabot recreate` on PRs #34 and #49 (or wait for the next Dependabot PR that touches bundled deps) and confirm:
  - `rebuild-dist` succeeds and pushes a signed commit.
  - `gh api repos/:owner/:repo/commits/<head-sha> --jq '.commit.verification'` returns `{verified: true, reason: "valid", ...}`.
  - The PR auto-merges.
- [ ] Confirm Dependabot PRs whose dependency change does not affect `dist/` (dev-deps groups, github-actions groups) still take the no-op path and merge as before.
- [ ] Verify `git_committer_name` and `git_committer_email` resolve to non-empty values in the runner log of the Import GPG step (the action prints the resolved committer identity).