### PR TITLE
docs: rename Quick start to Minimal quick start; add markdown-link-check config

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -1,0 +1,12 @@
+{
+  "aliveStatusCodes": [200, 206, 429],
+  "httpHeaders": [
+    {
+      "headers": { "Accept": "text/html" },
+      "urls": ["https://github.com/", "https://docs.github.com/"]
+    }
+  ],
+  "retryCount": 2,
+  "retryOn429": true,
+  "timeout": "10s"
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 AI-powered code review GitHub Action using [OpenAI Codex](https://github.com/openai/codex-action). Three-job design with security isolation: read-only prepare job (diff chunking, prompt assembly), read-only review job (parallel chunk reviews via `openai/codex-action`), and write-access publish job (chunk merging, inline PR comments, per-file summaries, verdict). Fully configurable prompts, models, confidence thresholds, and user allowlists.
 
-## Quick start
+## Minimal quick start
 
 Create `.github/workflows/codex-review.yaml` in your repository:
 
@@ -179,7 +179,7 @@ See [`defaults/review-reference.md`](defaults/review-reference.md) for the struc
 ## Setup
 
 1. Add `OPENAI_API_KEY` as a repository secret (Settings > Secrets and variables > Actions)
-2. Create the workflow file as shown in [Quick start](#quick-start)
+2. Create the workflow file as shown in [Minimal quick start](#minimal-quick-start)
 3. Optionally create `.github/codex/review-reference.md` for repo-specific review rules
 4. Open a pull request — the review appears automatically
 


### PR DESCRIPTION
## Summary

Re-scoped subset of #35 — only the parts that ship complete, self-contained content:

- Renames `## Quick start` → `## Minimal quick start` in `README.md` and updates the inbound link in the Setup section.
- Adds `.markdown-link-check.json` at the repo root for downstream docs issues (#36–#45) to reuse for local anchor validation.

This PR intentionally does **not** pre-create empty stub headings for `## Trust model`, `## Security guidance`, `## Production workflow example`, or `## Adopting in enterprise environments`. Each downstream issue (#36–#43) creates its own heading when it has real content to put in it; standard merge conflicts handle ordering. Shipping placeholder text that references issue numbers would couple the published README to tracker state and leave dangling references if any of the downstream issues stalls.

The affected downstream issues (#35, #36, #37, #38, #39, #40, #41, #43) have been updated in place to remove stub-coordination ACs and add a per-PR ``git log origin/main -- README.md`` check that lets whichever filler PR lands first create the parent heading. #42 already authored its section as top-level and needed no change.

## Verification

- `node -e \"JSON.parse(require('fs').readFileSync('.markdown-link-check.json','utf8'))\"` exits 0.
- `npx markdown-link-check --config .markdown-link-check.json README.md` reports 8 / 8 links OK, including the renamed `#minimal-quick-start` anchor.
- Repo-wide grep for `#quick-start` returns only `CHANGELOG.md` hits (frozen historical entries, intentionally untouched).

## Test plan

- [ ] Confirm README renders on GitHub: the `## Minimal quick start` heading is at H2, the Setup-section link `[Minimal quick start](#minimal-quick-start)` resolves on click.
- [ ] Confirm `.markdown-link-check.json` parses as valid JSON in the GitHub UI.
- [ ] Spot-check that `ignorePatterns` is absent from the config (anchor validation is load-bearing for downstream issues).

Closes #35.