### PR TITLE
chore: add CODEOWNERS to require maintainer review on all paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @milanhorvatovic

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
+# Require code owner approval on every path.
+# Works in combination with the "Require review from Code Owners"
+# rule on the default branch. While this repo has a single maintainer
+# all changes must go through them; once co-maintainers are added,
+# narrow this to trust-boundary paths (workflows, action.yaml, dist/).
+
 * @milanhorvatovic


### PR DESCRIPTION
## Summary

Add `.github/CODEOWNERS` with a single wildcard rule routing every path to `@milanhorvatovic`. An inline comment documents the wildcard scope and the plan to narrow it later.

## Why this matters

Without a CODEOWNERS file, "code owner" is undefined and any code-owner-review requirement enforced on the default branch matches nothing. This file establishes the maintainer as the code owner for every path so that code-owner-based review requirements have something to resolve against, and so the GitHub UI surfaces the maintainer as a suggested reviewer on every PR.

## Test plan

- [ ] Confirm the file renders correctly on GitHub's CODEOWNERS UI (`Settings → Code and automation → Code owners`) with no syntax warnings.