### PR TITLE
docs: add Trust model section and refresh SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,12 @@
 
 | Version | Supported |
 |---------|-----------|
-| 1.x | Yes |
+| 2.x | Yes |
+| 1.x | No (see [CHANGELOG](../CHANGELOG.md) for migration to 2.x) |
+
+## Data destinations
+
+PR diffs and metadata leave the runner only via two destinations: **GitHub** (PR context, posting the review, artifact storage) and **OpenAI** (via the SHA-pinned [`openai/codex-action`](https://github.com/openai/codex-action) invoked from `review/action.yaml`). This repository operates no maintainer-owned backend, proxy, analytics service, or telemetry pipeline that receives diffs. See the [Trust model](../README.md#trust-model) section in the README for the full statement.
 
 ## Reporting a Vulnerability
 
@@ -18,6 +23,12 @@ We will acknowledge receipt within 48 hours and aim to release a fix within 7 da
 
 ## Security Considerations
 
-This action processes untrusted input (PR diffs and metadata). It mitigates prompt injection via backtick neutralisation, dynamic fencing, and untrusted-data labelling. The two-action architecture isolates read-only review from write-access publishing.
+This action processes untrusted input (PR diffs and metadata). It mitigates prompt injection via backtick neutralisation, dynamic fencing, and untrusted-data labelling.
+
+The three-job architecture splits responsibilities by permission scope:
+
+- `prepare` (`contents: read`) — builds the PR diff, splits it into chunks, and assembles prompts. No write access; no API key.
+- `review` (`contents: read`) — invokes `openai/codex-action` per chunk in parallel. Receives the OpenAI API key but has no write access to the repository.
+- `publish` (`contents: read`, `pull-requests: write`) — merges chunk reviews and posts the PR review with inline comments. Never sees the OpenAI API key.
 
 If you believe any of these defences can be bypassed, please report it using the process above.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -27,8 +27,8 @@ This action processes untrusted input (PR diffs and metadata). It mitigates prom
 
 The three-job architecture splits responsibilities by permission scope:
 
-- `prepare` (`contents: read`) — builds the PR diff, splits it into chunks, and assembles prompts. No write access; no API key.
-- `review` (`contents: read`) — invokes `openai/codex-action` per chunk in parallel. Receives the OpenAI API key but has no write access to the repository.
-- `publish` (`contents: read`, `pull-requests: write`) — merges chunk reviews and posts the PR review with inline comments. Never sees the OpenAI API key.
+- `prepare` (`contents: read`) — builds the PR diff, splits it into chunks, and assembles prompts. No write access; does not require or receive the OpenAI API key.
+- `review` (`contents: read`) — invokes `openai/codex-action` per chunk in parallel. This is the only job that requires the OpenAI API key, and it has no write access to the repository.
+- `publish` (`contents: read`, `pull-requests: write`) — merges chunk reviews and posts the PR review with inline comments. Does not require or receive the OpenAI API key.
 
 If you believe any of these defences can be bypassed, please report it using the process above.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository does **not** operate any maintainer-owned backend, proxy, analyt
 Two trust questions are commonly conflated; they have different answers:
 
 - *"Does OpenAI see the diff?"* — **Yes.** The review job invokes `openai/codex-action`, which calls OpenAI's API with the prompt and the diff. This is the explicit purpose of the action.
-- *"Does the action maintainer see the diff?"* — **No.** No maintainer-operated destination exists. The action's source is auditable in this repository, and `openai/codex-action` is SHA-pinned in [`review/action.yaml`](review/action.yaml) (currently `@086169432f1d2ab2f4057540b1754d550f6a1189`, v1.4) so its behaviour cannot change under you without a visible bump in this repo.
+- *"Does the action maintainer see the diff?"* — **No.** No maintainer-operated destination exists. The action's source is auditable in this repository, and `openai/codex-action` is SHA-pinned in [`review/action.yaml`](review/action.yaml) (currently `@086169432f1d2ab2f4057540b1754d550f6a1189`, v1.4) so the referenced commit is immutable unless this repo bumps the SHA. (Runtime behaviour of OpenAI's API and model selection are outside this guarantee — see OpenAI's data-handling terms.)
 
 This action reduces risk when wired safely (read-only `prepare` and `review`, write access scoped to `publish`), but it does not make sending diffs to OpenAI risk-free. Evaluate OpenAI's data-handling terms separately for your organisation.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,22 @@
 
 AI-powered code review GitHub Action using [OpenAI Codex](https://github.com/openai/codex-action). Three-job design with security isolation: read-only prepare job (diff chunking, prompt assembly), read-only review job (parallel chunk reviews via `openai/codex-action`), and write-access publish job (chunk merging, inline PR comments, per-file summaries, verdict). Fully configurable prompts, models, confidence thresholds, and user allowlists.
 
+## Trust model
+
+PR diffs, title, body, and metadata leave your runner only via two destinations:
+
+- **GitHub** — for fetching the PR base commit, posting the review, and storing inter-job artifacts. This is expected behaviour for any GitHub Action.
+- **OpenAI** — via [`openai/codex-action`](https://github.com/openai/codex-action), which sends the prompt (including the diff) to OpenAI's API to generate the review.
+
+This repository does **not** operate any maintainer-owned backend, proxy, analytics service, or telemetry pipeline that receives diffs. There is no data destination beyond GitHub and OpenAI. The action does not phone home, and it does not collect usage data beyond what `openai/codex-action` itself does.
+
+Two trust questions are commonly conflated; they have different answers:
+
+- *"Does OpenAI see the diff?"* — **Yes.** The review job invokes `openai/codex-action`, which calls OpenAI's API with the prompt and the diff. This is the explicit purpose of the action.
+- *"Does the action maintainer see the diff?"* — **No.** No maintainer-operated destination exists. The action's source is auditable in this repository, and `openai/codex-action` is SHA-pinned in [`review/action.yaml`](review/action.yaml) (currently `@086169432f1d2ab2f4057540b1754d550f6a1189`, v1.4) so its behaviour cannot change under you without a visible bump in this repo.
+
+This action reduces risk when wired safely (read-only `prepare` and `review`, write access scoped to `publish`), but it does not make sending diffs to OpenAI risk-free. Evaluate OpenAI's data-handling terms separately for your organisation.
+
 ## Minimal quick start
 
 Create `.github/workflows/codex-review.yaml` in your repository:


### PR DESCRIPTION
Fixes #37

## Summary

- Adds a top-level **Trust model** section to `README.md`, between the description and Minimal quick start. The section names the two outbound destinations (GitHub and OpenAI), states explicitly that no maintainer-operated backend, proxy, analytics service, or telemetry pipeline exists, and separates the two trust questions teams commonly conflate ("OpenAI sees the diff" vs. "the maintainer sees the diff").
- Updates `.github/SECURITY.md`:
  - **Supported Versions** — drops v1.x as supported (links `CHANGELOG.md` for migration), declares v2.x supported.
  - **Data destinations** — new subsection mirroring the README Trust model in two sentences and linking back to it.
  - **Security Considerations** — rewrites the stale "two-action architecture" wording to describe the v2.0.0 three-job design (`prepare` / `review` / `publish`) with each job's permission scope and API-key exposure.

## Verification

### Trust boundary greps (verified 2026-04-26)

`src/` — only `https://github.com` host references:

```bash
grep -rnE "https?://|fetch\(|axios|node-fetch|undici|got\(|\brequest\(|superagent|from ['\"]https?['\"]|from ['\"]child_process['\"]|spawn\(|execFile\(|[^A-Za-z_.]exec\(" src --include="*.ts" | grep -v ".test.ts"
```

```
src/publish/main.ts:140:  const serverUrl = process.env.GITHUB_SERVER_URL || "https://github.com";
src/github/git.ts:19:      const host = process.env.GITHUB_SERVER_URL ?? "https://github.com";
```

Action YAML — only `openai/codex-action` once GitHub-owned `actions/*` are excluded:

```bash
grep -rnE "uses:\s*[^#]+" prepare/action.yaml review/action.yaml publish/action.yaml | grep -vE "uses:\s*actions/"
```

```
review/action.yaml:35:    - uses: openai/codex-action@086169432f1d2ab2f4057540b1754d550f6a1189 # v1.4
```

### Issue-body grep corrections

The expected outputs in #37 were slightly off; the patterns above are what the AC ("returned only GitHub hosts") actually verifies as written.

- `src/` grep — original alternation matched `RegExp.prototype.exec` and picked up `src/publish/main.ts:31  CHUNK_OUTPUT_PATTERN.exec(name)`. Tightened pattern requires a non-identifier char before `exec(`.
- Action YAML grep — original returned three matches in `review/action.yaml`: `actions/download-artifact`, `openai/codex-action`, `actions/upload-artifact`. The two `actions/*` references are GitHub-owned, so the trust claim still holds, but filtering them out makes the AC verifiable verbatim.

### Unconditional-security wording sweep

`grep -nE "\b(secure|security|safe|isolat|safely|prevents|protects)\b" README.md`:

```
6:  ... Three-job design with security isolation ...
22: This action reduces risk when wired safely ...
104: The workflow is split into three jobs for security isolation:
```

All three are factual mechanism statements naming the job-level permission split. No edits needed beyond the new conditional wording added in line 22.

### Markdown link check

`npx markdown-link-check --config .markdown-link-check.json` on both touched files — 13 links, all pass, including the new `../README.md#trust-model` anchor from `SECURITY.md`.

## Cross-link follow-up

The Trust model section mentions SHA pinning as plain prose (no anchor link to `#pinning-the-action`). PR #55 (issue #36) introduces the canonical `## Security guidance` → `### Pinning the action` subsection; once that lands, the prose here can be tightened to a direct anchor link. No bundle-order dependency declared — #37 is P1 and ships independently.

## Test plan

- [x] Render preview on GitHub: confirm Trust model heading renders at h2, anchor `#trust-model` resolves from `SECURITY.md`, supported-versions table renders, three-job bullet list renders.
- [ ] CI checks pass.