### PR TITLE
docs: add hardened production workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,124 @@ The same pattern applies to the `review` and `publish` actions. Pin all three su
 
 Inside this repository, `review/action.yaml` SHA-pins `openai/codex-action`. That transitive pin is only frozen for you when you pin this action itself to a full SHA — at the SHA you chose, `review/action.yaml` is fixed and the `openai/codex-action` reference cannot move. Pinning to `@v2` does not carry that guarantee: a future `v2` release can update the transitive SHA.
 
+## Production workflow example
+
+The Minimal quick start prioritises legibility. Use this section instead when adopting the action in a private repository, an enterprise org, or any setting where you want fewer assumptions about who can trigger reviews and tighter blast-radius controls. The example below preserves every guardrail from the Minimal quick start and adds runner pinning, an environment-scoped API key, an actor allowlist, immutable SHAs for this action's three sub-actions, per-job timeouts, and a same-repo trigger restriction.
+
+### One-time repo setup
+
+The example references a GitHub Environment named `codex-review` that scopes the OpenAI API key. Configure it once before adopting the workflow:
+
+1. Navigate to **Settings → Environments → New environment** and create one named `codex-review` (the workflow references this string verbatim — lowercase, hyphen).
+2. Inside that environment, add `OPENAI_API_KEY` as an **environment secret**, not a repository secret. If a repo-scoped copy already exists, remove it after confirming the environment-scoped copy works — that way a future workflow without `environment: codex-review` cannot read the key.
+3. Leave **Required reviewers** empty. The `review` job uses a matrix strategy, so a required reviewer would prompt once per chunk and block every PR. The environment exists only to scope the secret; PR-level gating is handled by the `allow-users` allowlist below.
+4. Leave **Deployment branches** at the default (all branches) unless you want to restrict reviews to PRs targeting specific branches.
+
+If step 1 is missed, the `review` job fails at schedule time with `The job was not started because it requires environment 'codex-review' which does not exist.` If step 2 is missed and the secret only exists at repo scope, `${{ secrets.OPENAI_API_KEY }}` resolves to an empty string inside the `review` job and `openai/codex-action` fails authentication.
+
+### Workflow
+
+Create `.github/workflows/codex-review.yaml`:
+
+```yaml
+name: Codex code review (hardened)
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    # Skip drafts; refuse fork PRs so secrets and broader permissions never see fork-controlled code.
+    if: ${{ !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-24.04 # pinned image; bump as GitHub retires older runner versions
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    outputs:
+      skipped: ${{ steps.prepare.outputs.skipped }}
+      has-changes: ${{ steps.prepare.outputs.has-changes }}
+      chunk-count: ${{ steps.prepare.outputs.chunk-count }}
+      chunk-matrix: ${{ steps.prepare.outputs.chunk-matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # all jobs check out the same SHA the workflow was triggered on
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: prepare
+        # SHA corresponds to tag v2.0.0 — update when adopting a new release.
+        uses: milanhorvatovic/codex-ai-code-review-action/prepare@af72a5bd7330432cee97137b04d04edebde80149 # v2.0.0
+        with:
+          allow-users: alice,bob,charlie # replace with real GitHub usernames; an empty value allows everyone
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: steps.prepare.outputs.skipped != 'true' && steps.prepare.outputs.has-changes == 'true'
+        with:
+          name: codex-prepare
+          path: .codex/
+          include-hidden-files: true # .codex/ is dot-prefixed; without this the upload silently skips it
+          retention-days: 1 # ephemeral hand-off; default 90 days burns storage and lengthens diff retention
+
+  review:
+    needs: prepare
+    if: needs.prepare.outputs.skipped != 'true' && needs.prepare.outputs.has-changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    environment: codex-review # scopes OPENAI_API_KEY; do not add required reviewers (matrix would trigger one prompt per chunk)
+    permissions:
+      contents: read
+    timeout-minutes: 30 # applies per matrix leg, not total — bound on a single chunk's Codex run, not a budget across all chunks
+    strategy:
+      fail-fast: false # one failing chunk must not cancel the others; partial output is recoverable
+      matrix: ${{ fromJson(needs.prepare.outputs.chunk-matrix) }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: milanhorvatovic/codex-ai-code-review-action/review@af72a5bd7330432cee97137b04d04edebde80149 # v2.0.0
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          chunk: ${{ matrix.chunk }}
+
+  publish:
+    needs: [prepare, review]
+    # always() keeps publish running when a review matrix leg fails so partial output still posts.
+    if: always() && needs.prepare.outputs.skipped != 'true' && needs.prepare.outputs.has-changes == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: .codex/
+          merge-multiple: true
+
+      - uses: milanhorvatovic/codex-ai-code-review-action/publish@af72a5bd7330432cee97137b04d04edebde80149 # v2.0.0
+        with:
+          github-token: ${{ github.token }}
+          expected-chunks: ${{ needs.prepare.outputs.chunk-count }}
+          retain-findings: false # explicit for auditors; matches the action default
+          # fail-on-missing-chunks: "true" # available in the next tagged release; uncomment after bumping the SHAs above
+```
+
+When you adopt a release that contains [issue #44](https://github.com/milanhorvatovic/codex-ai-code-review-action/issues/44), bump the three `codex-ai-code-review-action` SHAs to that release and uncomment `fail-on-missing-chunks: "true"` to make the publish step fail closed when any chunk is missing.
+
 ## Architecture
 
 The workflow is split into three jobs for security isolation:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Inside this repository, `review/action.yaml` SHA-pins `openai/codex-action`. Tha
 
 ## Production workflow example
 
-The Minimal quick start prioritises legibility. Use this section instead when adopting the action in a private repository, an enterprise org, or any setting where you want fewer assumptions about who can trigger reviews and tighter blast-radius controls. The example below preserves every guardrail from the Minimal quick start and adds runner pinning, an environment-scoped API key, an actor allowlist, immutable SHAs for this action's three sub-actions, per-job timeouts, and a same-repo trigger restriction.
+The Minimal quick start prioritises legibility. Use this section instead when adopting the action in a private repository, an enterprise org, or any setting where you want fewer assumptions about who can trigger reviews and tighter blast-radius controls. The example below preserves every guardrail from the Minimal quick start and adds runner pinning, an environment-scoped API key, a PR-author allowlist (gated on `pull_request.user.login`, not `github.actor`, so a maintainer re-run does not bypass it), immutable SHAs for this action's three sub-actions, per-job timeouts, and a same-repo trigger restriction.
 
 ### One-time repo setup
 
@@ -153,7 +153,7 @@ The example references a GitHub Environment named `codex-review` that scopes the
 3. Leave **Required reviewers** empty. The `review` job uses a matrix strategy, so a required reviewer would prompt once per chunk and block every PR. The environment exists only to scope the secret; PR-level gating is handled by the `allow-users` allowlist below.
 4. Leave **Deployment branches** at the default (all branches) unless you want to restrict reviews to PRs targeting specific branches.
 
-If step 1 is missed, the `review` job fails at schedule time with `The job was not started because it requires environment 'codex-review' which does not exist.` If step 2 is missed and the secret only exists at repo scope, `${{ secrets.OPENAI_API_KEY }}` resolves to an empty string inside the `review` job and `openai/codex-action` fails authentication.
+If step 1 is missed, the `review` job fails at schedule time with `The job was not started because it requires environment 'codex-review' which does not exist.` If `OPENAI_API_KEY` is not defined anywhere, `${{ secrets.OPENAI_API_KEY }}` resolves to an empty string and `openai/codex-action` fails authentication. If the secret exists only at repository scope, the workflow still runs because repository secrets remain visible to jobs that declare an `environment:` — the workflow appears healthy but the environment-scoping guardrail is not enforced until the repo-scoped copy is removed.
 
 ### Workflow
 


### PR DESCRIPTION
Closes #42

## Summary

- Adds a **Production workflow example** section to `README.md`, between *Security guidance* and *Architecture*, so teams adopting the action in private or enterprise repositories can copy a complete hardened workflow without inventing their own.
- Preserves every guardrail from the Minimal quick start (concurrency, draft skip, no-changes gate, full prepare outputs, `fail-fast: false`, `always()` on publish, third-party SHA pins, `include-hidden-files: true`, `retention-days: 1`) and adds runner pinning (`ubuntu-24.04`), same-repo trigger restriction, environment-scoped `OPENAI_API_KEY` via a `codex-review` GitHub Environment, a non-empty `allow-users` placeholder, immutable v2.0.0 SHA pins for the three sub-actions, per-job timeouts, and `retain-findings: false` made explicit for auditors. Each added guardrail carries a one-line inline comment.
- Section prose covers the one-time repo setup (4-step Settings walkthrough), the matrix-interaction caveat for required reviewers, and the two diagnosable failure modes (missing environment, secret only at repo scope).
- `fail-on-missing-chunks: "true"` is a commented-out placeholder. #44 is merged but not yet released; a trailing paragraph tells adopters to bump the SHAs and uncomment the input once a release containing #44 is adopted.

## Verification

### actionlint

YAML extracted to `/tmp/hardened-example.yaml` and linted with `actionlint 1.7.12`:

```bash
actionlint /tmp/hardened-example.yaml
```

Exit 0, no findings.

### markdown-link-check

```bash
npx --yes markdown-link-check --config .markdown-link-check.json README.md
```

11 links checked, all pass (includes the new reference to issue #44).

### Acceptance-criteria audit

All code-side AC items from #42 covered:

- Three-job structure with full prepare outputs, upload-artifact, download-artifact (`merge-multiple: true`).
- Same-repo restriction + `skipped != 'true' && has-changes == 'true'` gate on review and publish.
- `expected-chunks` wired to `needs.prepare.outputs.chunk-count`.
- Action's own `uses:` are full v2.0.0 SHAs with `# v2.0.0` trailing comments.
- Third-party SHAs match the Minimal quick start verbatim (no drift introduced).
- Minimal `permissions:` per job; `timeout-minutes:` per job (10/30/10).
- `runs-on: ubuntu-24.04` everywhere; `ref: ${{ github.event.pull_request.head.sha }}` on every checkout.
- `strategy.fail-fast: false` on review; publish `if:` starts with `always() && ...`.
- `include-hidden-files: true`, `retention-days: 1`, and skipped/has-changes guard preserved on prepare's upload step.

`allow-users` gate correctness is covered by the existing unit suite at `src/core/allowlist.test.ts` — no new tests required.

## Deviation from issue text

The issue prescribes `fail-on-missing-chunks: "true"` live "once #44 ships". #44 is merged but not yet released, so the input would be rejected by the v2.0.0 publish action this example pins to. Following the issue's own fallback clause ("If #44 is not yet merged, include this as a comment-only placeholder"), the input is commented out and a trailing paragraph below the YAML tells adopters how to enable it after bumping the SHA. This also aligns with the project rule that version bumps are batched into release PRs, not feature PRs.

## Test plan

- [ ] CI checks pass.