### PR TITLE
docs: add Responsibility boundary subsection to Security guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AI-powered code review GitHub Action using [OpenAI Codex](https://github.com/ope
 
 PR diffs, title, body, and metadata leave your runner only via two destinations:
 
-- **GitHub** — for fetching the PR base commit, posting the review, and storing inter-job artifacts. This is expected behaviour for any GitHub Action.
+- **GitHub** — for fetching the PR base commit, posting the review, and storing inter-job artifacts. This is expected behavior for any GitHub Action.
 - **OpenAI** — via [`openai/codex-action`](https://github.com/openai/codex-action), which sends the prompt (including the diff) to OpenAI's API to generate the review.
 
 This repository does **not** operate any maintainer-owned backend, proxy, analytics service, or telemetry pipeline that receives diffs. There is no data destination beyond GitHub and OpenAI. The action does not phone home, and it does not collect usage data beyond what `openai/codex-action` itself does.
@@ -17,9 +17,9 @@ This repository does **not** operate any maintainer-owned backend, proxy, analyt
 Two trust questions are commonly conflated; they have different answers:
 
 - *"Does OpenAI see the diff?"* — **Yes.** The review job invokes `openai/codex-action`, which calls OpenAI's API with the prompt and the diff. This is the explicit purpose of the action.
-- *"Does the action maintainer see the diff?"* — **No.** No maintainer-operated destination exists. The action's source is auditable in this repository, and `openai/codex-action` is SHA-pinned in [`review/action.yaml`](review/action.yaml) (currently `@086169432f1d2ab2f4057540b1754d550f6a1189`, v1.4) so the referenced commit is immutable unless this repo bumps the SHA. (Runtime behaviour of OpenAI's API and model selection are outside this guarantee — see OpenAI's data-handling terms.)
+- *"Does the action maintainer see the diff?"* — **No.** No maintainer-operated destination exists. The action's source is auditable in this repository, and `openai/codex-action` is SHA-pinned in [`review/action.yaml`](review/action.yaml) (currently `@086169432f1d2ab2f4057540b1754d550f6a1189`, v1.4) so the referenced commit is immutable unless this repo bumps the SHA. (Runtime behavior of OpenAI's API and model selection are outside this guarantee — see OpenAI's data-handling terms.)
 
-This action reduces risk when wired safely (read-only `prepare` and `review`, write access scoped to `publish`), but it does not make sending diffs to OpenAI risk-free. Evaluate OpenAI's data-handling terms separately for your organisation.
+This action reduces risk when wired safely (read-only `prepare` and `review`, write access scoped to `publish`), but it does not make sending diffs to OpenAI risk-free. Evaluate OpenAI's data-handling terms separately for your organization.
 
 ## Minimal quick start
 
@@ -150,7 +150,7 @@ Fork PRs cannot run the `review` job under `pull_request`. GitHub does not pass 
 
 ### Private repos
 
-Diffs leave the repository boundary and reach OpenAI via [`openai/codex-action`](https://github.com/openai/codex-action). Adopt this action only if that data transfer is acceptable under your organisation's policy.
+Diffs leave the repository boundary and reach OpenAI via [`openai/codex-action`](https://github.com/openai/codex-action). Adopt this action only if that data transfer is acceptable under your organization's policy.
 
 Apply every recommendation from [Public repos](#public-repos) — `pull_request`, SHA pinning, `allow-users`, minimum `permissions:` — and add three private-repo controls:
 
@@ -158,7 +158,7 @@ Apply every recommendation from [Public repos](#public-repos) — `pull_request`
 - **Same-repo restriction.** Gate every job on `github.event.pull_request.head.repo.full_name == github.repository` so a fork PR cannot trigger a private-repo review.
 - **Default `retain-findings`.** Leave `retain-findings` at its default (`false`). Long-lived artifacts retain the diff and the model's findings; opt in only when an auditor or compliance regime requires it.
 
-For organisations whose policy forbids running non-vendor public actions even when SHA-pinned, the [fork/internal-mirror adoption path](#adopting-in-enterprise-environments) describes how to host a wrapped fork inside the org instead.
+For organizations whose policy forbids running non-vendor public actions even when SHA-pinned, the [fork/internal-mirror adoption path](#adopting-in-enterprise-environments) describes how to host a wrapped fork inside the org instead.
 
 ### Responsibility boundary
 
@@ -166,7 +166,7 @@ This action handles review orchestration and privilege separation within the rev
 
 ## Production workflow example
 
-The Minimal quick start prioritises legibility. Use this section instead when adopting the action in a private repository, an enterprise org, or any setting where you want fewer assumptions about who can trigger reviews and tighter blast-radius controls. The example below preserves every guardrail from the Minimal quick start and adds runner pinning, an environment-scoped API key, a PR-author allowlist (gated on `pull_request.user.login`, not `github.actor`, so a maintainer re-run does not bypass it), immutable SHAs for this action's three sub-actions, per-job timeouts, and a same-repo trigger restriction.
+The Minimal quick start prioritizes legibility. Use this section instead when adopting the action in a private repository, an enterprise org, or any setting where you want fewer assumptions about who can trigger reviews and tighter blast-radius controls. The example below preserves every guardrail from the Minimal quick start and adds runner pinning, an environment-scoped API key, a PR-author allowlist (gated on `pull_request.user.login`, not `github.actor`, so a maintainer re-run does not bypass it), immutable SHAs for this action's three sub-actions, per-job timeouts, and a same-repo trigger restriction.
 
 ### One-time repo setup
 
@@ -378,7 +378,7 @@ See [`defaults/review-reference.md`](defaults/review-reference.md) for the struc
 
 ## Adopting in enterprise environments
 
-Some organisations have policies that prohibit running non-vendor public actions in sensitive repositories — even when those actions are SHA-pinned. The fork-and-wrap pattern documented below is a first-class adoption path for those environments, not a workaround.
+Some organizations have policies that prohibit running non-vendor public actions in sensitive repositories — even when those actions are SHA-pinned. The fork-and-wrap pattern documented below is a first-class adoption path for those environments, not a workaround.
 
 The pattern uses two distinct internal repositories:
 
@@ -406,7 +406,7 @@ Build a reusable workflow inside `<org>/codex-review-internal` that wraps the fo
 
 ### 4. Restrict product repos to the internal version
 
-Configure org-level policy so that product repos can only invoke `<org>/codex-review-internal/.github/workflows/...` and not the public `<owner>/codex-ai-code-review-action/...` references. GitHub allows actions to be shared across repositories within the same organisation without Marketplace publication via **Settings → Actions → Allow actions from repositories within the organization**.
+Configure org-level policy so that product repos can only invoke `<org>/codex-review-internal/.github/workflows/...` and not the public `<owner>/codex-ai-code-review-action/...` references. GitHub allows actions to be shared across repositories within the same organization without Marketplace publication via **Settings → Actions → Allow actions from repositories within the organization**.
 
 ### 5. Pull upstream updates deliberately
 
@@ -440,7 +440,7 @@ jobs:
 
 The `concurrency:` block is the consumer's responsibility, not the wrapper's: the consumer owns the `pull_request` trigger, so it owns the policy for cancelling in-flight runs when a new push lands. Omitting it lets repeated pushes overlap and race when uploading or downloading artifacts.
 
-A reusable workflow can _narrow_ but not _widen_ the caller's `GITHUB_TOKEN` scope. The `permissions:` block above is required whenever the consumer repo's (or its org's) default `GITHUB_TOKEN` permissions are read-only — i.e. anything narrower than `pull-requests: write`. Omitting it then makes the wrapper inherit the read-only default, and the publish job fails with `Resource not accessible by integration` even though the wrapper itself declares `pull-requests: write` at job level. Repos whose default `GITHUB_TOKEN` already includes `pull-requests: write` work without the explicit block, but spelling it out at the call site is recommended for defence-in-depth and to make the workflow portable across orgs with different defaults.
+A reusable workflow can _narrow_ but not _widen_ the caller's `GITHUB_TOKEN` scope. The `permissions:` block above is required whenever the consumer repo's (or its org's) default `GITHUB_TOKEN` permissions are read-only — i.e. anything narrower than `pull-requests: write`. Omitting it then makes the wrapper inherit the read-only default, and the publish job fails with `Resource not accessible by integration` even though the wrapper itself declares `pull-requests: write` at job level. Repos whose default `GITHUB_TOKEN` already includes `pull-requests: write` work without the explicit block, but spelling it out at the call site is recommended for defense-in-depth and to make the workflow portable across orgs with different defaults.
 
 ### Example wrapper workflow
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ Apply every recommendation from [Public repos](#public-repos) — `pull_request`
 
 For organisations whose policy forbids running non-vendor public actions even when SHA-pinned, the [fork/internal-mirror adoption path](#adopting-in-enterprise-environments) describes how to host a wrapped fork inside the org instead.
 
+### Responsibility boundary
+
+This action handles review orchestration and privilege separation within the review pipeline. It does not replace caller responsibilities: safe trigger selection, same-repo restrictions, environment gating, secret management, and organizational approval policy. The architecture reduces risk when wired into a workflow safely; it does not provide security by default.
+
 ## Production workflow example
 
 The Minimal quick start prioritises legibility. Use this section instead when adopting the action in a private repository, an enterprise org, or any setting where you want fewer assumptions about who can trigger reviews and tighter blast-radius controls. The example below preserves every guardrail from the Minimal quick start and adds runner pinning, an environment-scoped API key, a PR-author allowlist (gated on `pull_request.user.login`, not `github.actor`, so a maintainer re-run does not bypass it), immutable SHAs for this action's three sub-actions, per-job timeouts, and a same-repo trigger restriction.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For organisations whose policy forbids running non-vendor public actions even wh
 
 ### Responsibility boundary
 
-This action handles review orchestration and privilege separation within the review pipeline. It does not replace caller responsibilities: safe trigger selection, same-repo restrictions, environment gating, secret management, and organizational approval policy. The architecture reduces risk when wired into a workflow safely; it does not provide security by default.
+This action handles review orchestration and privilege separation within the review pipeline. It does not replace caller responsibilities: safe trigger selection, same-repo restrictions, environment gating, secret management, and organisational approval policy. The architecture reduces risk when wired into a workflow safely; it does not provide security by default.
 
 ## Production workflow example
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For organisations whose policy forbids running non-vendor public actions even wh
 
 ### Responsibility boundary
 
-This action handles review orchestration and privilege separation within the review pipeline. It does not replace caller responsibilities: safe trigger selection, same-repo restrictions, environment gating, secret management, and organisational approval policy. The architecture reduces risk when wired into a workflow safely; it does not provide security by default.
+This action handles review orchestration and privilege separation within the review pipeline. It does not replace caller responsibilities: safe trigger selection, same-repo restrictions, environment gating, secret management, and organizational approval policy. The architecture reduces risk when wired into a workflow safely; it does not provide security by default.
 
 ## Production workflow example
 


### PR DESCRIPTION
## Summary

This PR has two scopes — both intentional, the second per direct request during review:

1. **Responsibility boundary subsection (the issue's actual ask).** Adds a `### Responsibility boundary` subsection to `## Security guidance` in `README.md`, stating that the action handles orchestration and privilege separation but does not replace caller responsibilities (safe trigger selection, same-repo restrictions, environment gating, secret management, organizational approval policy). Body uses the verbatim prose from the issue, as a plain paragraph, placed after `### Private repos` and before `## Production workflow example`.
2. **UK→US English sweep across `README.md`.** Triggered by a Copilot review on commit 1 that flagged the new subsection's US spelling as inconsistent with pre-existing UK spellings elsewhere in `README.md`. The repo's intended convention is US English; the existing UK words are pre-existing drift, not the convention. Per scope decision during review, this PR cleans up the README in scope. Remaining UK spellings in `.github/SECURITY.md` and `CHANGELOG.md` are tracked in #66, plus a CONTRIBUTING.md style note to prevent future drift.

Closes #41.

## Sweep details (scope 2)

| File | Line(s) | UK | US |
|---|---|---|---|
| `README.md` | 12, 20 | `behaviour` | `behavior` |
| `README.md` | 22, 153, 161, 381, 409 | `organisation` / `organisations` / `organisation's` | `organization` / `organizations` / `organization's` |
| `README.md` | 169 | `prioritises` | `prioritizes` |
| `README.md` | 443 | `defence-in-depth` | `defense-in-depth` |

The verbatim GitHub UI label `Allow actions from repositories within the organization` (README.md:409) is intentionally left as-is because it quotes GitHub's settings UI.

## Notes for reviewers

- The parent `## Security guidance` heading was already created on `main` by #54 (`Do not use pull_request_target`). Branch is current with `origin/main` (`5028a54`); no rebase needed.
- Audit grep from issue #41 (`grep -nEi "secure by default|is secure|guarantees|fully protect|prevents all" README.md`) returns no matches — no soften-pass needed.
- No new links introduced; cross-references to existing subsections were considered and intentionally deferred to keep the subsection text strictly verbatim from the issue.
- A previous commit briefly switched `organizational` → `organisational` (commit `31e2792`) to align with then-detected UK usage; that was reverted in `e9d4ef5` after confirming the project convention is US English. The verbatim-prose claim in scope 1 holds at the final SHA.

## Test plan

- [x] `grep -nEi "secure by default|is secure|guarantees|fully protect|prevents all" README.md` — no matches
- [x] `npx markdown-link-check --config .markdown-link-check.json README.md` — 21/21 links pass
- [x] Repo-wide UK-English regex sweep returns only out-of-scope matches in `.github/SECURITY.md` and `CHANGELOG.md`, both tracked in #66
- [ ] Render preview on GitHub: confirm `### Responsibility boundary` renders at H3 under `## Security guidance`, anchor resolves, paragraph renders as prose