### PR TITLE
chore: unify and bump third-party action pins to latest

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,15 +15,15 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/init@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
         with:
           languages: javascript-typescript
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/autobuild@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        uses: github/codeql-action/analyze@7fc6561ed893d15cec696e062df840b21db27eb0 # v4.35.2

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ jobs:
       - id: prepare
         uses: milanhorvatovic/codex-ai-code-review-action/prepare@v2
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.prepare.outputs.skipped != 'true' && steps.prepare.outputs.has-changes == 'true'
         with:
           name: codex-prepare
@@ -220,7 +220,7 @@ jobs:
         with:
           allow-users: alice,bob,charlie # replace with real GitHub usernames; an empty value allows everyone
 
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.prepare.outputs.skipped != 'true' && steps.prepare.outputs.has-changes == 'true'
         with:
           name: codex-prepare
@@ -477,7 +477,7 @@ jobs:
         uses: <org>/codex-ai-code-review-action-fork/prepare@<full-sha> # v2.0.0
         with:
           allow-users: alice,bob,charlie
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.prepare.outputs.skipped != 'true' && steps.prepare.outputs.has-changes == 'true'
         with:
           name: codex-prepare

--- a/review/action.yaml
+++ b/review/action.yaml
@@ -27,12 +27,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: codex-prepare
         path: .codex/
 
-    - uses: openai/codex-action@086169432f1d2ab2f4057540b1754d550f6a1189 # v1.4
+    - uses: openai/codex-action@c300d2798ce5b59a7667c806b5e3a3d2c397ed2f # v1.7
       with:
         effort: ${{ inputs.effort }}
         model: ${{ inputs.model }}
@@ -42,7 +42,7 @@ runs:
         prompt-file: .codex/chunk-${{ inputs.chunk }}-prompt.md
         sandbox: read-only
 
-    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: codex-review-chunk-${{ inputs.chunk }}
         path: .codex/chunk-${{ inputs.chunk }}-output.json


### PR DESCRIPTION
## Summary

- Bumps every third-party Action that has a newer upstream release and unifies pins so the same SHA + fully-qualified tag comment is used everywhere the action appears (composite `action.yaml`, workflows, `README.md`).
- Closes the originally-reported `actions/download-artifact` drift in `review/action.yaml:30` (#46) and, while there, fixes additional drift and stale pins discovered during a repo-wide audit so integrators get one predictable, reproducible configuration.
- No `package.json` version bump and no `CHANGELOG.md` edit — release process owns those. `dist/` is unchanged because these actions are consumed at runtime, not bundled.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/download-artifact` | `v8.0.0` (`review/action.yaml:30`) + `v8.0.1` (README ×3, `tests.yaml`) | `v8.0.1` (`3e5f45b2…`) everywhere |
| `actions/upload-artifact` | `v7.0.0` (`review/action.yaml:45`, README ×3) + `v7.0.1` (`tests.yaml:38`) | `v7.0.1` (`043fb46d…`) everywhere |
| `openai/codex-action` | `v1.4` (`086169432f…`) | `v1.7` (`c300d2798c…`) |
| `github/codeql-action/{init,autobuild,analyze}` | SHA `95e58e9a…` with comment `# v4` | SHA `7fc6561e…` with comment `# v4.35.2` |
| `actions/checkout` (codeql.yaml only) | Tag comment `# v6` | Tag comment `# v6.0.2` (SHA unchanged) |

Already on latest, no change required: `actions/setup-node@v6.4.0`, `crazy-max/ghaction-import-gpg@v7.0.0`, `dependabot/fetch-metadata@v3.1.0`.

### Notes on the codex-action minor jump (v1.4 → v1.7)

The inputs this repo passes to `openai/codex-action` (`effort`, `model`, `openai-api-key`, `output-file`, `output-schema-file`, `prompt-file`, `sandbox`) are unchanged across v1.4 → v1.7. Material changes between those releases:

- v1.5 — hardens shell interpolation in the action's own workflows (`openai/codex-action#74`).
- v1.6 — enables Linux bubblewrap support on GitHub-hosted runners (`openai/codex-action#77`).
- v1.7 — restricts a bot permission bypass (`openai/codex-action#89`).

None alter the public `with:` contract for our usage.

### Notes on codeql-action re-pin

The previous SHA (`95e58e9a…`) was historically associated with v4.35.2 (the merge commit message references it) but is no longer the canonical `v4.35.2` tag SHA, and no longer matches the floating `v4` major tag either. Re-pinning to `7fc6561e…` (the canonical `v4.35.2` SHA) and using a fully-qualified tag comment matches the style used everywhere else in the repo and removes the ambiguity.

## Files changed

- `review/action.yaml` — three `uses:` lines (`download-artifact`, `openai/codex-action`, `upload-artifact`).
- `README.md` — three `actions/upload-artifact` references (lines 60, 223, 480).
- `.github/workflows/codeql.yaml` — `init`, `autobuild`, `analyze` re-pinned; `actions/checkout` tag comment normalized.

No other files touched. Verified with:

```
grep -rEHn 'uses: [a-zA-Z0-9._/-]+@[a-f0-9]{40}' --include='*.yaml' --include='*.yml' --include='*.md' . | grep -v node_modules | grep -v dist/
```

Every match shows the same SHA + tag comment per action across all locations.

## Trust-boundary classification

Not a trust-boundary change. None of these bumps alter data destinations, prompts, telemetry, permissions, or artifact contents. No `trust-boundary` label and no CHANGELOG callout required, per the release-discipline policy.

## Test plan

- [x] `npm run lint` — passes (eslint clean).
- [x] `npm run typecheck` — passes (`tsc --noEmit`).
- [x] `npm run build` — passes; `dist/` unchanged (`git status` clean after build).
- [x] `npm test` — 204/204 passing (12 test files).
- [x] `actionlint` on every file under `.github/workflows/` — no errors.
      (Note: `actionlint` does not validate composite `action.yaml` files, so `review/action.yaml` is not in scope for that check; the original issue's reference to running `actionlint` against it is not applicable.)
- [x] Repo-wide pin verification: `grep -rEHn 'uses: [a-zA-Z0-9._/-]+@[a-f0-9]{40}' --include='*.yaml' --include='*.yml' --include='*.md' .` returns one SHA per action across all locations.

Closes #46