### PR TITLE
ci: add release: <level> label contract for PR-driven releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,20 @@
 
 None.
 
+## Release label
+
+<!--
+  Apply exactly one of:
+
+  - `release: major` — major version bump (breaking change)
+  - `release: minor` — minor version bump (new feature)
+  - `release: patch` — patch version bump (fix or documentation only)
+  - `release: skip`  — excluded from the next release (chore, infra, internal-only, release-prep)
+
+  The required check `verify-pr-release-label` enforces exactly one.
+  Dependabot PRs auto-carry `release: patch`.
+-->
+
 ## Test plan
 
 - [ ] `npm run lint`

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -12,6 +12,7 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+      - "release: patch"
     schedule:
       day: "monday"
       interval: "weekly"
@@ -29,6 +30,7 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+      - "release: patch"
     schedule:
       day: "monday"
       interval: "weekly"

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -19,9 +19,24 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          MATCHES="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
-            --jq '[.labels[].name | select(startswith("release: "))] | length')"
-          if [ "$MATCHES" != "1" ]; then
-            echo "::error::PR must carry exactly one of: 'release: major', 'release: minor', 'release: patch', 'release: skip'. Found $MATCHES."
+
+          ALL_LABELS_JSON="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            --jq '.labels | map(.name)')"
+
+          INVALID="$(jq -rn --argjson l "$ALL_LABELS_JSON" '
+            $l
+            | map(select(startswith("release: ")))
+            | . - ["release: major", "release: minor", "release: patch", "release: skip"]
+            | join(", ")
+          ')"
+          if [ -n "$INVALID" ]; then
+            echo "::error::PR carries non-canonical release label(s): $INVALID. Allowed: 'release: major', 'release: minor', 'release: patch', 'release: skip'."
+            exit 1
+          fi
+
+          COUNT="$(jq -n --argjson l "$ALL_LABELS_JSON" \
+            '$l | map(select(startswith("release: "))) | length')"
+          if [ "$COUNT" != "1" ]; then
+            echo "::error::PR must carry exactly one of: 'release: major', 'release: minor', 'release: patch', 'release: skip'. Found $COUNT."
             exit 1
           fi

--- a/.github/workflows/verify-pr-release-label.yaml
+++ b/.github/workflows/verify-pr-release-label.yaml
@@ -1,0 +1,27 @@
+name: verify-pr-release-label
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  verify-pr-release-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify exactly one release label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          MATCHES="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            --jq '[.labels[].name | select(startswith("release: "))] | length')"
+          if [ "$MATCHES" != "1" ]; then
+            echo "::error::PR must carry exactly one of: 'release: major', 'release: minor', 'release: patch', 'release: skip'. Found $MATCHES."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,24 @@ New code should include tests. Aim to maintain or improve coverage.
 - JSON key ordering: Keep keys alphabetically sorted unless an existing file establishes a different order.
 - Merge strategy: Squash-merge via `gh pr merge --squash` (matching the Dependabot auto-merge workflow at `.github/workflows/dependabot-auto-merge.yaml`).
 - Documentation prose: Follows the [Documentation tone and style](#documentation-tone-and-style) section below.
+- PR titles: informally follow Conventional Commits (`type(scope): subject`). The title is for human readability; release intent is set by the `release: *` label, not parsed from the title.
+
+### Release label
+
+Every PR carries exactly one of:
+
+- `release: major` — major version bump (breaking change)
+- `release: minor` — minor version bump (new feature)
+- `release: patch` — patch version bump (fix or documentation only)
+- `release: skip`  — excluded from the next release (chore, infra, internal-only, release-prep)
+
+The required check `verify-pr-release-label` enforces this on every PR. Reviewers apply or correct the label as part of approval. Dependabot PRs auto-carry `release: patch`; trust-boundary Dependabot bumps additionally receive `trust-boundary` from maintainers during review (both labels coexist).
+
+Release-preparation PRs themselves carry `release: skip` — the release IS the bump, so the PR is not contributing a level.
+
+### Squash-body policy
+
+When merging via squash, replace the auto-generated commit-list body with a hand-written summary paragraph. The PR title, labels, and CHANGELOG entry are the durable record; the squash body is for `git log -p` readers. Release tooling reads PR metadata (title, labels), not commit messages — do not encode release semantics in the squash body.
 
 ## Documentation tone and style
 


### PR DESCRIPTION
Closes #73.

## Summary

- Adds the `release: <level>` label contract: every PR carries exactly one of `release: major | minor | patch | skip`.
- New required-status workflow `verify-pr-release-label` enforces "exactly one" on every `pull_request` against `main`.
- Dependabot PRs auto-carry `release: patch`; `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` document the contract.

## Trust boundary impact

None. The new workflow uses no third-party Actions; permissions limited to `pull-requests: read`; no data egress.

## Release label

`release: skip` — process/CI-only change; no consumer-visible behavior. The published action's runtime contract is unchanged.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` (302/302 pass)
- [x] `npm run verify:prose-style`
- [x] `actionlint` against the new workflow (and the rest of the repo — clean)
- [x] `npm run build` not required: no source under `src/` changed; `verify-dist` confirms
- [x] On PR open the workflow fails because no `release: *` label is applied. After applying `release: skip`, the check turns green.
- [x] Multi-label rejection verified by inspection: `[ "$MATCHES" != "1" ]` rejects both zero and more-than-one through the same branch.

## Intentional deviations from issue #73's literal text

Decided during planning before implementation; flagging so reviewers see them as decisions rather than oversights:

- **`CONTRIBUTING.md` placement.** Issue specified a new `## Pull request conventions` top-level section. Implemented under the existing `## Pull request guidelines` as `### Release label` and `### Squash-body policy`, with one bullet appended to `### Conventions` (PR-title note). Avoids heading echo.
- **Workflow naming.** Workflow `name:` and job key both `verify-pr-release-label` (issue draft used `Verify Release Label` + job `verify`). Required so the check context binds cleanly to the existing ruleset convention (`test`, `verify-dist`).
- **Trigger types.** `[opened, reopened, labeled, unlabeled, synchronize]`. Dropped `edited` (no-op for label state); added `reopened` (re-evaluate on reopen).
- **`branches: [main]` filter** added on `pull_request` to mirror `verify-action-pins.yaml` and `verify-dist.yaml`.
- **PR template addition** not in the issue's file list; added as in-scope per planning discussion. Descriptive (no checkbox) since labels live in metadata, not the body.
- **`actionlint` acceptance-criteria bullet** dropped here; tracked in #79.

## Preflight (already done)

- Four labels created on the repo: `gh label list | grep -c '^release: '` → `4`.

## Backfill

`gh pr list --state open` is `[]` at PR-open time → no backfill needed. Contingency snippet documented in #73 if a parallel PR appears before merge.