### PR TITLE
ci: auto-approve Dependabot PRs so auto-merge can complete

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -145,20 +145,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVE_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+        # This step is intentionally fail-open: any failure (missing token, revoked PAT,
+        # insufficient PAT scope, transient GitHub API error, malformed response) emits a
+        # warning and exits 0. `set -e` is deliberately *not* enabled — a hard failure here
+        # would cause GitHub Actions to skip the subsequent auto-merge enable step, which
+        # would degrade behavior worse than the prior state (no approval AND no auto-merge).
+        # The intended fallback is: the PR waits for manual review with auto-merge already
+        # enabled, which matches the prior behavior.
         run: |
-          set -euo pipefail
+          set -uo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::warning::DEPENDABOT_APPROVE_TOKEN is not set — skipping auto-approval. The PR will require manual review before auto-merge can complete. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and store it under Settings → Secrets and variables → Dependabot → DEPENDABOT_APPROVE_TOKEN."
             exit 0
           fi
-          has_trust_boundary() {
-            gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary")'
-          }
-          if [ "$(has_trust_boundary)" = "true" ]; then
+          if ! label_state=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary")'); then
+            echo "::warning::Failed to query trust-boundary label state; skipping auto-approval. Auto-merge will still be attempted; the PR will wait for manual review if approval cannot be posted."
+            exit 0
+          fi
+          if [ "$label_state" = "true" ]; then
             echo "trust-boundary label is now present (applied after workflow start); skipping auto-approval."
             exit 0
           fi
-          gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, non-trust-boundary update)." "$PR_URL"
+          if ! gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, non-trust-boundary update)." "$PR_URL"; then
+            echo "::warning::Failed to post auto-approval review (likely a revoked or insufficiently-scoped DEPENDABOT_APPROVE_TOKEN, or a transient GitHub API error). Auto-merge will still be enabled; the PR will wait for manual review."
+            exit 0
+          fi
 
       - name: Auto-merge patch and minor updates
         if: >-

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -128,6 +128,38 @@ jobs:
       # The `if:` clauses below evaluate against the event payload captured at workflow start.
       # That payload can be stale by the time this step runs (label applied during the run).
       # The runtime checks inside `run:` close that TOCTOU race — see the comments there.
+      #
+      # Auto-approval runs before auto-merge enable so that, by the time auto-merge fires,
+      # the required code-owner review is already in place. The repo's branch ruleset on
+      # `main` requires one approving review with code-owner approval, and `GITHUB_TOKEN`
+      # cannot approve PRs (Dependabot also cannot approve its own). A separately-issued
+      # PAT belonging to a code-owner is required and must be stored as a *Dependabot*
+      # secret (workflows triggered by Dependabot do not have access to Actions secrets).
+      # When the secret is unset, the step warns and skips — auto-merge is still enabled
+      # and the PR waits for manual approval, matching the prior behaviour.
+      - name: Approve PR (so required-review check passes)
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          && !contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')
+          && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
+        env:
+          GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVE_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::DEPENDABOT_APPROVE_TOKEN is not set — skipping auto-approval. The PR will require manual review before auto-merge can complete. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and store it under Settings → Secrets and variables → Dependabot → DEPENDABOT_APPROVE_TOKEN."
+            exit 0
+          fi
+          has_trust_boundary() {
+            gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary")'
+          }
+          if [ "$(has_trust_boundary)" = "true" ]; then
+            echo "trust-boundary label is now present (applied after workflow start); skipping auto-approval."
+            exit 0
+          fi
+          gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, non-trust-boundary update)." "$PR_URL"
+
       - name: Auto-merge patch and minor updates
         if: >-
           steps.metadata.outputs.update-type != 'version-update:semver-major'
@@ -163,6 +195,12 @@ jobs:
   # prevents re-enabling — it does not revoke a previously-enabled auto-merge. This job runs on
   # the `labeled` pull_request event and explicitly disables auto-merge so the PR stays open
   # for manual maintainer review and merging.
+  #
+  # A previously-posted auto-approval review (from the approve step above) is intentionally
+  # left in place. Disabling auto-merge is sufficient to stop the automatic merge; the
+  # ruleset's `dismiss_stale_reviews_on_push: true` will clear the bot review on the next push,
+  # and the maintainer who applied the label can dismiss it manually if they want a clean
+  # review state before re-evaluating.
   disable-auto-merge-on-trust-boundary:
     if: >-
       github.event.action == 'labeled' &&

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -147,12 +147,18 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         # This step is intentionally fail-open: any failure (missing token, revoked PAT,
         # insufficient PAT scope, transient GitHub API error, malformed response) emits a
-        # warning and exits 0. `set -e` is deliberately *not* enabled — a hard failure here
-        # would cause GitHub Actions to skip the subsequent auto-merge enable step, which
-        # would degrade behavior worse than the prior state (no approval AND no auto-merge).
-        # The intended fallback is: the PR waits for manual review with auto-merge already
-        # enabled, which matches the prior behavior.
+        # warning and exits 0. A hard failure here would cause GitHub Actions to skip the
+        # subsequent auto-merge enable step, which would degrade behavior worse than the
+        # prior state (no approval AND no auto-merge). The fallback is: the PR waits for
+        # manual review with auto-merge already enabled, matching the prior behavior.
+        #
+        # GitHub Actions invokes the default bash shell as `bash --noprofile --norc -eo
+        # pipefail {0}`, so errexit is on by default. We explicitly disable it (`set +e`)
+        # because future edits could add an unwrapped `gh` call and silently regress the
+        # fail-open invariant. Every external command below is independently guarded with
+        # `if !` and emits a warning before `exit 0`; preserve that pattern when extending.
         run: |
+          set +e
           set -uo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "::warning::DEPENDABOT_APPROVE_TOKEN is not set — skipping auto-approval. The PR will require manual review before auto-merge can complete. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and store it under Settings → Secrets and variables → Dependabot → DEPENDABOT_APPROVE_TOKEN."

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -136,7 +136,7 @@ jobs:
       # PAT belonging to a code-owner is required and must be stored as a *Dependabot*
       # secret (workflows triggered by Dependabot do not have access to Actions secrets).
       # When the secret is unset, the step warns and skips — auto-merge is still enabled
-      # and the PR waits for manual approval, matching the prior behaviour.
+      # and the PR waits for manual approval, matching the prior behavior.
       - name: Approve PR (so required-review check passes)
         if: >-
           steps.metadata.outputs.update-type != 'version-update:semver-major'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,22 @@ The auto-merge workflow at [`.github/workflows/dependabot-auto-merge.yaml`](.git
 
 All three coexist intentionally. The exclude list is the declarative defense (fail-closed for known dependencies); the label guard's runtime checks close the TOCTOU race during the auto-merge step itself; the reactive disable job catches PRs labeled later in the PR's lifecycle. Removing any layer weakens the policy.
 
+#### Auto-approval
+
+The default-branch ruleset on `main` requires one approving code-owner review before merge. `GITHUB_TOKEN` cannot approve PRs and Dependabot cannot approve its own PRs, so without an additional approver auto-merge would never complete. To close that gap, the auto-merge job posts an approving review *before* enabling auto-merge, gated by the same three trust-boundary guards above (semver-major bumps, the `openai/codex-action` exclude, and the `trust-boundary` label).
+
+The approval is posted using a fine-grained PAT belonging to a code-owner, stored as the Dependabot secret **`DEPENDABOT_APPROVE_TOKEN`**. The PAT must be:
+
+- Scoped to this repository.
+- Granted `Pull requests: write` permission (sufficient to submit a review).
+- Owned by a user listed in [`.github/CODEOWNERS`](.github/CODEOWNERS), so the review counts toward the code-owner requirement.
+
+Configure under **Settings → Secrets and variables → Dependabot → New secret**. Workflows triggered by Dependabot do not have access to Actions secrets, so the value must live under the Dependabot scope.
+
+When the secret is unset, the approval step emits a warning and exits cleanly — auto-merge is still enabled, but the PR waits for a manual approving review.
+
+Auto-approval reviews carry the marker body `Auto-approved by the Dependabot Auto-Merge workflow (...)` so they are easy to identify in the PR review list. If a maintainer later applies the `trust-boundary` label, the reactive disable job revokes auto-merge but does not dismiss the bot review; the ruleset's `dismiss_stale_reviews_on_push: true` will clear it on the next push, and the maintainer can dismiss it manually before re-evaluating.
+
 ## Release process
 
 1. Update `version` in `package.json`


### PR DESCRIPTION
## Summary

- Adds an Approve PR step to the auto-merge job in `.github/workflows/dependabot-auto-merge.yaml`. It runs **before** the auto-merge enable step and is gated by the same three trust-boundary guards (semver-major, `openai/codex-action` exclude, `trust-boundary` label).
- Approval is posted with a new **optional** Dependabot secret `DEPENDABOT_APPROVE_TOKEN`. When unset, the step emits a `::warning::` and exits cleanly — auto-merge is still enabled and the PR waits for manual review (prior behaviour).
- Updates `CONTRIBUTING.md` → *Dependabot enforcement* with a new **Auto-approval** subsection covering the secret's required scope, why a separate PAT is needed (`GITHUB_TOKEN` cannot approve, Dependabot cannot self-approve), how it interacts with the reactive `disable-auto-merge-on-trust-boundary` job, and where to configure it.

## Why

The default-branch ruleset on `main` requires one approving code-owner review with code-owner approval. With nothing posting that review, two open Dependabot PRs (#81 codeql-action major, #82 dev-deps patch) showed `mergeStateStatus: BLOCKED` despite all checks green. PR #82 has auto-merge enabled but cannot complete; PR #81 also fails the semver-major guard so wouldn't auto-merge regardless.

Option 2 from triage: have the workflow auto-approve under the same trust-boundary policy. Selected over (1) approving manually each time and (3) loosening the ruleset. The PAT-based approach keeps the code-owner invariant (the approver is a real code-owner from `CODEOWNERS`) and remains fail-closed (no token → no approval → manual review still required).

## Required setup before this helps

1. Create a fine-grained PAT scoped to this repository.
2. Permission: **Pull requests → Write** (sufficient to submit a review).
3. The PAT owner must be a code-owner — currently `@milanhorvatovic` per `.github/CODEOWNERS`.
4. Store under **Settings → Secrets and variables → Dependabot → New secret**, name: `DEPENDABOT_APPROVE_TOKEN`. (Workflows triggered by Dependabot do not see Actions secrets.)

## Trust-boundary interaction

- **Pre-existing layers unchanged.** Exclude-by-name (`openai/codex-action`), label fast-path, runtime label re-checks in the auto-merge step, and the reactive `disable-auto-merge-on-trust-boundary` job all continue to apply.
- **New step uses identical guards.** A semver-major bump, a grouped bump that includes `openai/codex-action`, or a PR with the `trust-boundary` label is never auto-approved.
- **Late-applied label.** If a maintainer applies `trust-boundary` after auto-approval has been posted, the reactive disable job revokes auto-merge (unchanged). The bot review is intentionally left in place — `dismiss_stale_reviews_on_push: true` clears it on the next push, and the maintainer can dismiss manually before re-evaluating. This is documented in both the workflow comment and CONTRIBUTING.

## Test plan

- [ ] Configure `DEPENDABOT_APPROVE_TOKEN` per the setup steps above before merging this PR (otherwise the new step is a no-op warning).
- [ ] After merge, on the next Dependabot-triggered run for an existing open PR (e.g. trigger `synchronize` by pushing a no-op rebase, or wait for the next bump), confirm:
  - The Approve PR step posts a review with body starting `Auto-approved by the Dependabot Auto-Merge workflow`.
  - `gh pr view <n> --json reviewDecision` becomes `APPROVED`.
  - Auto-merge fires once required checks complete, and the PR merges.
- [ ] Verify the trust-boundary path: open or relabel a Dependabot PR with `trust-boundary` and confirm:
  - The Approve PR step is skipped (visible in the workflow log).
  - If approval was already posted before the label landed, the reactive disable job still revokes auto-merge cleanly.
- [ ] Verify graceful degradation: temporarily unset the secret in a fork or test setup and confirm the warning fires and auto-merge falls back to waiting for manual review without failing the workflow.

## Notes

- The two currently-open PRs (#81, #82) will not be auto-approved retroactively — they need a re-trigger. After merging this and configuring the secret, push a small commit to PR #82 (or close/reopen) to fire the workflow. PR #81 is semver-major and will continue to require manual review by design.