### PR TITLE
docs: document release-automation App identity in SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -52,10 +52,10 @@ The App has no organization permissions, no user permissions, no webhook, and no
 
 App credentials are stored at the repo level (Settings → Secrets and variables → Actions):
 
-- `RELEASE_APP_ID` (variable) — the App's numeric ID, public.
+- `RELEASE_APP_ID` (variable) — the App's numeric ID. Not a secret, but not intended for external publication either.
 - `RELEASE_APP_PRIVATE_KEY` (secret) — the App's signing key, used by `actions/create-github-app-token` to mint short-lived installation tokens at workflow runtime.
 
-Tokens minted from the App are scoped to a single workflow run and expire automatically. Maintainers rotate the private key by generating a new one on the App settings page and replacing the secret value; old keys remain valid until manually revoked.
+Installation tokens minted by the App are short-lived: they expire automatically (one-hour default) and `actions/create-github-app-token` revokes them when the job ends. They are not cryptographically bound to a specific workflow run, so a leaked token remains usable until revocation or expiry — treat it as a secret while it lives. Maintainers rotate the private key by generating a new one on the App settings page and replacing the secret value; old keys remain valid until manually revoked.
 
 ### Why an App instead of `GITHUB_TOKEN`
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -32,3 +32,31 @@ The three-job architecture splits responsibilities by permission scope:
 - `publish` (`contents: read`, `pull-requests: write`) — merges chunk reviews and posts the PR review with inline comments. Does not require or receive the OpenAI API key.
 
 If you believe any of these defenses can be bypassed, please report it using the process above.
+
+## Release automation identity
+
+Release automation is performed by a dedicated GitHub App installed only on this repository. The App identity is `codex-review-action-release-bot[bot]` in audit logs and PR authorship.
+
+### Permission scope
+
+The App has these repository permissions, and only these:
+
+- `Contents: Read and write` — push release branches, create version tags
+- `Pull requests: Read and write` — open release PRs and post-release refresh PRs
+- `Workflows: Read and write` — required by GitHub when pushes touch any workflow file
+- `Metadata: Read-only` — required by GitHub for any installed App
+
+The App has no organization permissions, no user permissions, no webhook, and no installations on other repositories.
+
+### Credentials
+
+App credentials are stored at the repo level (Settings → Secrets and variables → Actions):
+
+- `RELEASE_APP_ID` (variable) — the App's numeric ID, public.
+- `RELEASE_APP_PRIVATE_KEY` (secret) — the App's signing key, used by `actions/create-github-app-token` to mint short-lived installation tokens at workflow runtime.
+
+Tokens minted from the App are scoped to a single workflow run and expire automatically. Maintainers rotate the private key by generating a new one on the App settings page and replacing the secret value; old keys remain valid until manually revoked.
+
+### Why an App instead of `GITHUB_TOKEN`
+
+PRs opened by the default `GITHUB_TOKEN` do not trigger downstream workflows (a documented anti-recursion safeguard). Release automation requires that release PRs run their normal CI checks before merging, so the App identity is necessary. PATs are avoided because they tie automation to a person and have broader permission scopes than this use needs.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -52,10 +52,10 @@ The App has no organization permissions, no user permissions, no webhook, and no
 
 App credentials are stored at the repo level (Settings → Secrets and variables → Actions):
 
-- `RELEASE_APP_ID` (variable) — the App's numeric ID. Not a secret, but not intended for external publication either.
-- `RELEASE_APP_PRIVATE_KEY` (secret) — the App's signing key, used by `actions/create-github-app-token` to mint short-lived installation tokens at workflow runtime.
+- `RELEASE_APP_ID` (variable) — the App's numeric ID. Not a secret; stored as a repo variable so workflows can reference it via `vars.RELEASE_APP_ID`.
+- `RELEASE_APP_PRIVATE_KEY` (secret) — the App's signing key. Release-automation workflows are expected to feed this into a token-minting Action (e.g. `actions/create-github-app-token`) to obtain short-lived installation tokens at runtime.
 
-Installation tokens minted by the App are short-lived: they expire automatically (one-hour default) and `actions/create-github-app-token` revokes them when the job ends. They are not cryptographically bound to a specific workflow run, so a leaked token remains usable until revocation or expiry — treat it as a secret while it lives. Maintainers rotate the private key by generating a new one on the App settings page and replacing the secret value; old keys remain valid until manually revoked.
+GitHub App installation tokens expire automatically (one-hour default) and are scoped to the installation rather than to a specific workflow run, so a leaked token remains usable until expiry or explicit revocation. Release-automation workflows are expected to mint a token at job start and revoke it at job end (the default post-step behavior of `actions/create-github-app-token`); the App identity itself does not enforce that. Maintainers rotate the private key by generating a new one on the App settings page and replacing the secret value; old keys remain valid until manually revoked.
 
 ### Why an App instead of `GITHUB_TOKEN`
 


### PR DESCRIPTION
## Summary

- Appends a new `## Release automation identity` section to `.github/SECURITY.md` after `## Security Considerations`.
- Documents the dedicated GitHub App used for release automation: identity (`codex-review-action-release-bot[bot]`), exact permission scope (`Contents`/`Pull requests`/`Workflows` write, `Metadata` read), credential storage (`RELEASE_APP_ID` variable + `RELEASE_APP_PRIVATE_KEY` secret), rotation procedure, and the rationale for an App over `GITHUB_TOKEN` (anti-recursion safeguard) or a PAT (broader scope, person-bound).
- Closes #75 from the in-repo perspective. The GitHub-UI-side acceptance criteria (App created, installed on this repo only, secrets stored, local `.pem` deleted) are performed via repo settings and tracked in the closing comment on #75.

## Trust boundary impact

None.

The new App is a maintainer-side release-process actor; it does not change any criterion in `CONTRIBUTING.md → Trust-boundary changes` (no outbound destination changes, no change to data sent to OpenAI, no telemetry, no change to permissions the action requires from adopters, no artifact-content change, no transitive-pin movement). Adopters consuming `@v2.x` see identical bytes regardless of how the release was produced. The maintainer-security audit angle (a new automated identity with `contents: write` on this repo) is documented in the new SECURITY.md section itself, which is the appropriate venue.

## Release label

\`release: patch\` — documentation-only change.

## Test plan

- [x] `npm run verify:prose-style` passes
- [x] `npm run verify:doc-pins` passes
- [x] Manual diff review of `.github/SECURITY.md`
- [x] `npm run lint`, `npm run typecheck`, `npm test`, `npm run build` — N/A (Markdown-only change in `.github/`; no source, scripts, or `dist/` affected)

## Out of scope

This PR does not introduce any workflow that consumes the App token. The first consumer is issue #76 (PR-driven release automation). Splitting the work this way (per #75's design) lets the App's existence and permission scope be audited in isolation before any workflow depends on it.