### PR TITLE
ci: lint workflows with actionlint

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,29 @@
+name: Lint Workflows
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Lint .github/workflows with actionlint
+        shell: bash
+        run: |
+          set -euo pipefail
+          actionlint_image='rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667' # v1.7.12
+          docker run --rm \
+            --env GITHUB_ACTIONS \
+            --volume "${GITHUB_WORKSPACE}:/repo" \
+            --workdir /repo \
+            "${actionlint_image}" \
+            -color

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,15 +107,17 @@ This invokes `scripts/verify-prose-style.ts`, which scans every text-bearing tra
 
 ## Workflow linting
 
-The files under `.github/workflows/` are linted with [`actionlint`](https://github.com/rhysd/actionlint) (with `shellcheck` integration) on every pull request and push to `main` via [`.github/workflows/actionlint.yaml`](.github/workflows/actionlint.yaml). The workflow runs the SHA-pinned `rhysd/actionlint` Docker image, which bundles `shellcheck` and `pyflakes`. Composite action files (the top-level `action.yaml`, `prepare/action.yaml`, `publish/action.yaml`, `review/action.yaml`, and `.github/actions/*/action.yaml`) are out of scope — actionlint only validates workflow shape; SHA-pinning across all of them is enforced by [`.github/workflows/verify-action-pins.yaml`](.github/workflows/verify-action-pins.yaml).
+The files under `.github/workflows/` are linted with [`actionlint`](https://github.com/rhysd/actionlint) (with `shellcheck` integration on `run:` blocks) on every pull request and push to `main` via [`.github/workflows/actionlint.yaml`](.github/workflows/actionlint.yaml). The workflow runs the SHA-pinned `rhysd/actionlint` Docker image, which bundles `shellcheck` and `pyflakes`. actionlint covers workflow YAML structure, expression syntax, context references, runner/`uses:` references, matrix shapes, and embedded shell scripts. Composite action files (the top-level `action.yaml`, `prepare/action.yaml`, `publish/action.yaml`, `review/action.yaml`, and `.github/actions/*/action.yaml`) are out of scope because actionlint targets workflow files, not composite action metadata; SHA-pinning across all of them is enforced by [`.github/workflows/verify-action-pins.yaml`](.github/workflows/verify-action-pins.yaml).
 
 To run the same lint locally, pick whichever path fits your platform:
 
 - **mise (recommended; matches the CI versions and works on macOS, Linux, and Windows via WSL).** `mise.toml` already pins `actionlint` and `shellcheck` alongside Node, so `mise install` provisions both. After that, `actionlint` runs from `$PATH`.
-- **Docker (no host install; identical to CI).**
+- **Docker (no host install; identical to CI).** Use the same digest pinned in [`.github/workflows/actionlint.yaml`](.github/workflows/actionlint.yaml) so the image is byte-identical to the one CI uses, not a tag that can be retargeted upstream:
 
   ```bash
-  docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color
+  docker run --rm -v "$PWD:/repo" --workdir /repo \
+    rhysd/actionlint@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
+    -color
   ```
 
 - **Native package managers.** macOS: `brew install actionlint shellcheck`. Linux: install `shellcheck` from your distro and `actionlint` from the [upstream releases](https://github.com/rhysd/actionlint/releases). Windows: `scoop install actionlint shellcheck`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,21 @@ npm run verify:prose-style
 
 This invokes `scripts/verify-prose-style.ts`, which scans every text-bearing tracked file, reports any UK English form with `file:line:column` precision, and exits non-zero on drift. The same script runs in CI on every pull request and push to `main` via [`.github/workflows/verify-prose-style.yaml`](.github/workflows/verify-prose-style.yaml). Each `UK_PATTERNS` entry is an anchored regex matching a complete UK word (e.g. `organis(?:e|es|ed|ing|ation|ations|ational|er|ers|able)`), so US English nouns that share a UK verb stem — `criticism`, `optimism`, `terrorism`, `organism`, `programmer`, `programmed`, `emphasis`, and so on — are not flagged. When a new UK form needs coverage, add an anchored pattern to `UK_PATTERNS` and a test case in `scripts/verify-prose-style.test.ts`. The `ALLOWED_WORDS` set is reserved for proper nouns whose canonical spelling collides with a UK English word (brand, party, or place names); add lowercased entries when one appears in repository prose.
 
+## Workflow linting
+
+The files under `.github/workflows/` are linted with [`actionlint`](https://github.com/rhysd/actionlint) (with `shellcheck` integration) on every pull request and push to `main` via [`.github/workflows/actionlint.yaml`](.github/workflows/actionlint.yaml). The workflow runs the SHA-pinned `rhysd/actionlint` Docker image, which bundles `shellcheck` and `pyflakes`. Composite action files (the top-level `action.yaml`, `prepare/action.yaml`, `publish/action.yaml`, `review/action.yaml`, and `.github/actions/*/action.yaml`) are out of scope — actionlint only validates workflow shape; SHA-pinning across all of them is enforced by [`.github/workflows/verify-action-pins.yaml`](.github/workflows/verify-action-pins.yaml).
+
+To run the same lint locally, pick whichever path fits your platform:
+
+- **mise (recommended; matches the CI versions and works on macOS, Linux, and Windows via WSL).** `mise.toml` already pins `actionlint` and `shellcheck` alongside Node, so `mise install` provisions both. After that, `actionlint` runs from `$PATH`.
+- **Docker (no host install; identical to CI).**
+
+  ```bash
+  docker run --rm -v "$PWD:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color
+  ```
+
+- **Native package managers.** macOS: `brew install actionlint shellcheck`. Linux: install `shellcheck` from your distro and `actionlint` from the [upstream releases](https://github.com/rhysd/actionlint/releases). Windows: `scoop install actionlint shellcheck`.
+
 ## Trust-boundary changes
 
 Changes that affect data destinations, forwarding, telemetry, auth scopes, or what callers must trust require explicit release-note treatment so adopters who have already hardened their workflow can re-review.

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
+actionlint = "1.7.12"
 node = "24.14.1"
+shellcheck = "0.11.0"


### PR DESCRIPTION
## Summary

Adds [`actionlint`](https://github.com/rhysd/actionlint) as a CI lint for `.github/workflows/*.yaml`, closing #79. Workflow expression syntax, shell-script bodies (via `shellcheck`), input/secret references, and matrix shapes are now validated on every PR and push to `main`. `verify-action-pins` continues to cover SHA-pinning; the two checks are complementary.

- New workflow `.github/workflows/actionlint.yaml` runs the SHA-pinned `rhysd/actionlint` Docker image (v1.7.12, manifest list digest `sha256:b1934e…`). The image bundles `shellcheck` and `pyflakes`, so no extra setup is needed in the runner.
- Composite action files (the top-level `action.yaml`, `prepare/action.yaml`, `publish/action.yaml`, `review/action.yaml`, and `.github/actions/*/action.yaml`) are intentionally out of scope — actionlint validates workflow shape (`on:`, `jobs:`) and rejects composite actions. SHA-pinning across all of them is already enforced by `verify-action-pins.yaml`.
- `mise.toml` pins `actionlint = "1.7.12"` and `shellcheck = "0.11.0"` so contributors using `mise install` get the same versions as CI on macOS, Linux, and Windows (WSL).
- New "Workflow linting" subsection in `CONTRIBUTING.md` documents three install paths: mise (recommended), Docker (zero-install, identical to CI), and native package managers (`brew`, distro `shellcheck` + upstream binary, `scoop`).

No findings to fix in existing workflows: actionlint with shellcheck integration ran clean across the current `.github/workflows/` set before any changes. The issue's hypothesis about `dependabot-auto-merge.yaml` did not surface anything.

## Versions

All three dependencies are at their latest published release:

- `rhysd/actionlint` — v1.7.12 (2026-03-30)
- `actions/checkout` — v6.0.2 (2026-01-09; matches the canonical pin used elsewhere in the repo)
- `shellcheck` — 0.11.0 (2025-08-04)

## Post-merge step (manual)

Once this lands and the workflow has run at least once on `main`, add the `actionlint` job to the `main` branch ruleset as a required status check. The next PR after merge can serve as the live verification that the gate is wired up correctly. Until the ruleset is updated the workflow is advisory.

## Trust boundary impact

None. `actionlint` runs entirely inside the GitHub Actions runner, processes only files already in the checkout, and emits no outbound traffic. No new permissions are requested (`contents: read` only). The `rhysd/actionlint` Docker image is pulled from Docker Hub by digest at workflow time; no runtime artifact contents change.

## Test plan

- [x] \`actionlint -shellcheck=shellcheck\` runs clean locally against \`.github/workflows/*.yaml\` (including the new \`actionlint.yaml\`).
- [x] \`npm run verify:doc-pins\` passes (Docker \`sha256:\` digests are not matched by the pin regex, so no false positives).
- [x] \`npm run verify:prose-style\` passes on the new CONTRIBUTING content.
- [x] First CI run on the PR shows the new \`Lint Workflows / actionlint\` job green.