### PR TITLE
chore: ignore .claude/ and local planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Claude Code per-project state (local-only: settings, hooks, scheduled-task lock)
+.claude/
+
+# Local planning and feedback notes (not source-controlled)
+docs/plans/
+docs/feedback/


### PR DESCRIPTION
## Summary

- Add `.claude/` to `.gitignore` — Claude Code's per-project state directory (`settings.local.json`, `scheduled_tasks.lock`); always local, never source-controlled.
- Add `docs/plans/` and `docs/feedback/` to `.gitignore` — local-only planning and review notes that scaffolded the recent README hardening + release-automation batch but are not part of the project's source of truth (the GitHub issues and merged PRs are).

No committed file in the tree references these paths (verified via `git ls-tree -r HEAD --name-only | xargs grep -l "docs/plans\|docs/feedback"` — zero hits).

## Test plan

- [ ] `git status` on a fresh checkout no longer shows `.claude/` or `docs/plans/` as untracked when those directories exist locally.
- [ ] `actionlint` and existing CI checks pass (no workflow changes in this PR).