### PR TITLE
fix: keep package-lock.json version in step with package.json

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,9 +18,13 @@ jobs:
         run: |
           set -euo pipefail
           PKG="$(jq -r .version package.json)"
-          LOCK_TOP="$(jq -r .version package-lock.json)"
+          LOCK_TOP="$(jq -r '.version // empty' package-lock.json)"
           LOCK_ROOT_PKG="$(jq -r '.packages[""].version // empty' package-lock.json)"
-          if [ "${PKG}" != "${LOCK_TOP}" ] || { [ -n "${LOCK_ROOT_PKG}" ] && [ "${PKG}" != "${LOCK_ROOT_PKG}" ]; }; then
+          if [ -z "${LOCK_TOP}" ] || [ -z "${LOCK_ROOT_PKG}" ]; then
+            echo "::error::package-lock.json is missing required version metadata (top='${LOCK_TOP}' root-pkg='${LOCK_ROOT_PKG}'); lockfileVersion 3 must include both."
+            exit 1
+          fi
+          if [ "${PKG}" != "${LOCK_TOP}" ] || [ "${PKG}" != "${LOCK_ROOT_PKG}" ]; then
             echo "::error::package.json=${PKG} but package-lock.json reports top=${LOCK_TOP} root-pkg=${LOCK_ROOT_PKG}"
             exit 1
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,6 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Verify package-lock.json version matches package.json
+        run: |
+          set -euo pipefail
+          PKG="$(jq -r .version package.json)"
+          LOCK_TOP="$(jq -r .version package-lock.json)"
+          LOCK_ROOT_PKG="$(jq -r '.packages[""].version // empty' package-lock.json)"
+          if [ "${PKG}" != "${LOCK_TOP}" ] || { [ -n "${LOCK_ROOT_PKG}" ] && [ "${PKG}" != "${LOCK_ROOT_PKG}" ]; }; then
+            echo "::error::package.json=${PKG} but package-lock.json reports top=${LOCK_TOP} root-pkg=${LOCK_ROOT_PKG}"
+            exit 1
+          fi
+
       - uses: ./.github/actions/setup-node-deps
 
       - name: Lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Auto-approval reviews carry the marker body `Auto-approved by the Dependabot Aut
 ### Automated release (default)
 
 1. Trigger `prepare-release.yaml` via the GitHub UI (`Actions → Prepare Release → Run workflow`). Optionally pass an explicit `version` (e.g. `2.1.0` or `2.1.0-rc.1`); leave empty to compute from the `release: <level>` labels of merged PRs since the last non-pre-release tag.
-2. The workflow opens a PR titled `release: v<X.Y.Z>` against `main` containing the `package.json` bump and the new `CHANGELOG.md` entry. Review it like any other PR. Re-running the workflow for the same target version updates the existing release branch and PR in place; the bot refuses to force-push if any non-bot commits are present on the release branch.
+2. The workflow opens a PR titled `release: v<X.Y.Z>` against `main` containing the `package.json` bump, the matching `package-lock.json` bump (top-level `version` and `packages[""].version` only — no dependency tree resolution), and the new `CHANGELOG.md` entry, all in the same commit. Review it like any other PR. Re-running the workflow for the same target version updates the existing release branch and PR in place; the bot refuses to force-push if any non-bot commits are present on the release branch.
 3. Squash-merge the release PR. The `release-on-merge.yaml` workflow tags the merge commit with `v<X.Y.Z>` and pushes the tag automatically.
 4. The tag push triggers `release.yaml`, which creates the GitHub Release with notes extracted from `CHANGELOG.md`, force-updates the major version tag (skipped for pre-releases), and opens a follow-up PR refreshing SHA-pinned self-references in `README.md` (skipped for pre-releases).
 5. Squash-merge the self-pin refresh PR.
@@ -187,7 +187,7 @@ Auto-approval reviews carry the marker body `Auto-approved by the Dependabot Aut
 
 Use this path when `prepare-release.yaml` is broken or an urgent hotfix needs cutting from a fresh local clone. Both flows produce identical output (a `v<X.Y.Z>` tag pointing at a commit on `main` with the right `package.json` version + `CHANGELOG.md` entry).
 
-1. Update `version` in `package.json`.
+1. Update `version` in `package.json`, then bump `package-lock.json` to the same version at both the top-level `version` and `packages[""].version`. Do not run `npm install --package-lock-only` or `npm version` for this — they re-resolve the dependency tree and would cause silent transitive bumps in a release-prep commit. A `jq`-based or hand edit of just those two lines is correct. The `tests.yaml` workflow rejects any PR where the two files disagree.
 2. Update `CHANGELOG.md` with the release date and any new entries.
    - **2b. Trust-boundary callout.** If the release contains any PRs labeled `trust-boundary`, add a dedicated subsection to the CHANGELOG entry:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codex-ai-code-review-action",
-  "version": "2.0.0",
+  "version": "2.1.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codex-ai-code-review-action",
-      "version": "2.0.0",
+      "version": "2.1.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@actions/artifact": "6.2.1",

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyChangelogUpdate,
   bumpPackageJsonVersion,
+  bumpPackageLockVersion,
   buildPrBody,
   categorizePullRequest,
   computeVersionBump,
@@ -359,6 +360,106 @@ describe("bumpPackageJsonVersion", () => {
   });
 });
 
+describe("bumpPackageLockVersion", () => {
+  function makeLock(overrides?: {
+    version?: string | undefined;
+    rootPackageVersion?: string | undefined;
+    omitTopVersion?: boolean;
+    omitRootPackage?: boolean;
+    omitRootPackageVersion?: boolean;
+    extraPackages?: Record<string, unknown>;
+  }): string {
+    const opts = overrides ?? {};
+    const rootPackage: Record<string, unknown> = {
+      name: "x",
+      license: "MIT",
+    };
+    if (!opts.omitRootPackageVersion) {
+      rootPackage.version = opts.rootPackageVersion ?? "1.0.0";
+    }
+    const packages: Record<string, unknown> = {};
+    if (!opts.omitRootPackage) {
+      packages[""] = rootPackage;
+    }
+    if (opts.extraPackages) {
+      Object.assign(packages, opts.extraPackages);
+    }
+    const top: Record<string, unknown> = {
+      name: "x",
+      lockfileVersion: 3,
+      requires: true,
+      packages,
+    };
+    if (!opts.omitTopVersion) {
+      top.version = opts.version ?? "1.0.0";
+      const ordered: Record<string, unknown> = {
+        name: top.name,
+        version: top.version,
+        lockfileVersion: top.lockfileVersion,
+        requires: top.requires,
+        packages: top.packages,
+      };
+      return `${JSON.stringify(ordered, null, 2)}\n`;
+    }
+    return `${JSON.stringify(top, null, 2)}\n`;
+  }
+
+  it("rewrites the top-level version and packages[''].version", () => {
+    const result = bumpPackageLockVersion(makeLock(), "1.1.0");
+    const parsed = JSON.parse(result);
+    expect(parsed.version).toBe("1.1.0");
+    expect(parsed.packages[""].version).toBe("1.1.0");
+  });
+
+  it("preserves a trailing newline when the input has one", () => {
+    const result = bumpPackageLockVersion(makeLock(), "1.1.0");
+    expect(result.endsWith("\n")).toBe(true);
+  });
+
+  it("preserves no-trailing-newline when the input has none", () => {
+    const content = makeLock().replace(/\n$/, "");
+    const result = bumpPackageLockVersion(content, "1.1.0");
+    expect(result.endsWith("\n")).toBe(false);
+  });
+
+  it("leaves extra packages entries (e.g. node_modules/foo) untouched", () => {
+    const content = makeLock({
+      extraPackages: {
+        "node_modules/foo": { version: "9.9.9" },
+        "node_modules/bar": { version: "0.0.1" },
+      },
+    });
+    const result = bumpPackageLockVersion(content, "1.1.0");
+    const parsed = JSON.parse(result);
+    expect(parsed.packages["node_modules/foo"].version).toBe("9.9.9");
+    expect(parsed.packages["node_modules/bar"].version).toBe("0.0.1");
+  });
+
+  it("rejects an invalid target version", () => {
+    expect(() => bumpPackageLockVersion(makeLock(), "v1.1.0")).toThrow(
+      /Strip the leading 'v'/,
+    );
+  });
+
+  it("throws when the top-level version field is absent", () => {
+    expect(() => bumpPackageLockVersion(makeLock({ omitTopVersion: true }), "1.1.0")).toThrow(
+      /no top-level 'version' field/,
+    );
+  });
+
+  it("throws when packages[''] is absent", () => {
+    expect(() => bumpPackageLockVersion(makeLock({ omitRootPackage: true }), "1.1.0")).toThrow(
+      /no 'packages\[""\]' entry/,
+    );
+  });
+
+  it("throws when packages[''].version is absent", () => {
+    expect(() =>
+      bumpPackageLockVersion(makeLock({ omitRootPackageVersion: true }), "1.1.0"),
+    ).toThrow(/no 'packages\[""\]\.version' field/);
+  });
+});
+
 describe("tagCommitTimestamp", () => {
   it("returns the trimmed git log output", () => {
     const calls: string[][] = [];
@@ -538,6 +639,18 @@ describe("runCli (dry-run integration)", () => {
       readFile: (path) => {
         if (path === "package.json")
           return `${JSON.stringify({ name: "x", version: "2.0.0" }, null, 2)}\n`;
+        if (path === "package-lock.json")
+          return `${JSON.stringify(
+            {
+              name: "x",
+              version: "2.0.0",
+              lockfileVersion: 3,
+              requires: true,
+              packages: { "": { name: "x", version: "2.0.0" } },
+            },
+            null,
+            2,
+          )}\n`;
         if (path === "CHANGELOG.md")
           return "# Changelog\n\n## [2.0.0] - 2026-04-07\n\n- prior\n";
         throw new Error(`unexpected read: ${path}`);
@@ -576,6 +689,8 @@ describe("runCli (dry-run integration)", () => {
     expect(stderr.join("")).toBe("");
     const out = stdout.join("");
     expect(out).toContain('"version": "2.1.0"');
+    expect(out).toContain('"lockfileVersion": 3');
+    expect(out).toContain("package-lock.json");
     expect(out).toContain("## [2.1.0] - 2026-05-01");
     expect(out).toContain("Target version: 2.1.0 (release)");
   });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -260,6 +260,29 @@ export function bumpPackageJsonVersion(content: string, newVersion: string): str
   return `${JSON.stringify(parsed, null, 2)}${trailing}`;
 }
 
+export function bumpPackageLockVersion(content: string, newVersion: string): string {
+  parseVersion(newVersion);
+  const trailing = content.endsWith("\n") ? "\n" : "";
+  const parsed = JSON.parse(content) as Record<string, unknown>;
+  if (!("version" in parsed)) {
+    throw new Error("package-lock.json has no top-level 'version' field");
+  }
+  const packages = parsed.packages;
+  if (typeof packages !== "object" || packages === null) {
+    throw new Error("package-lock.json has no 'packages' object");
+  }
+  const rootPackage = (packages as Record<string, unknown>)[""];
+  if (typeof rootPackage !== "object" || rootPackage === null) {
+    throw new Error("package-lock.json has no 'packages[\"\"]' entry");
+  }
+  if (!("version" in (rootPackage as Record<string, unknown>))) {
+    throw new Error("package-lock.json has no 'packages[\"\"].version' field");
+  }
+  parsed.version = newVersion;
+  (rootPackage as Record<string, unknown>).version = newVersion;
+  return `${JSON.stringify(parsed, null, 2)}${trailing}`;
+}
+
 export function selectLastNonPrereleaseTag(
   releases: Array<{ tagName: string; publishedAt: string; isPrerelease: boolean }>,
 ): { tagName: string; publishedAt: string } | undefined {
@@ -550,11 +573,14 @@ export function runCli(deps: PrepareReleaseDeps = {}): number {
     const isPre = isPrereleaseVersion(targetVersion);
 
     const updatedPackageJson = bumpPackageJsonVersion(packageJson, targetVersion);
+    const packageLock = readFile("package-lock.json");
+    const updatedPackageLock = bumpPackageLockVersion(packageLock, targetVersion);
     const changelog = readFile("CHANGELOG.md");
     const updatedChangelog = applyChangelogUpdate(changelog, targetVersion, today, prs);
 
     if (dryRun) {
       stdoutWrite(unifiedDiff("package.json", packageJson, updatedPackageJson));
+      stdoutWrite(unifiedDiff("package-lock.json", packageLock, updatedPackageLock));
       stdoutWrite(unifiedDiff("CHANGELOG.md", changelog, updatedChangelog));
       stdoutWrite(`# Target version: ${targetVersion} (${isPre ? "pre-release" : "release"})\n`);
       return 0;
@@ -598,14 +624,15 @@ export function runCli(deps: PrepareReleaseDeps = {}): number {
 
     runGit(["checkout", "-B", branch, "origin/main"]);
     writeFile("package.json", updatedPackageJson);
+    writeFile("package-lock.json", updatedPackageLock);
     writeFile("CHANGELOG.md", updatedChangelog);
     runGit(["config", "user.name", botLogin]);
     runGit(["config", "user.email", botEmail]);
-    runGit(["add", "package.json", "CHANGELOG.md"]);
+    runGit(["add", "package.json", "package-lock.json", "CHANGELOG.md"]);
     const stagedDiff = runGit(["diff", "--cached", "--name-only"]).trim();
     if (stagedDiff === "") {
       stdoutWrite(
-        `No changes for v${targetVersion}: package.json and CHANGELOG.md on origin/main already match the computed output. Skipping commit and PR update.\n`,
+        `No changes for v${targetVersion}: package.json, package-lock.json, and CHANGELOG.md on origin/main already match the computed output. Skipping commit and PR update.\n`,
       );
       return 0;
     }


### PR DESCRIPTION
Closes #90.

## Summary

`package.json` advanced to `2.1.0-rc.1` in the v2.1.0-rc.1 release-prep PR (#88), but `package-lock.json` stayed at `2.0.0` at both `version` and `packages[""].version` because the prepare-release writer block only updated `package.json` and `CHANGELOG.md`. Consumers diffing the released artefact saw mismatched metadata; tooling that keys off `package-lock.json` (`npm ci`, future SBOM/provenance generators) reported the wrong version.

This PR fixes the drift in three layers — script, lockfile, CI — and documents the joint bump.

## Changes (4 commits)

1. **`feat(prepare-release)`** — adds `bumpPackageLockVersion` (sibling to `bumpPackageJsonVersion`): surgical `JSON.parse` → mutate → `JSON.stringify(_, null, 2)` rewrite of top-level `version` and `packages[""].version`, preserving trailing newline. Strict on missing fields (`lockfileVersion: 3` always carries both). Writer block reads, bumps, writes, and `git add`s `package-lock.json` next to `package.json` so all three release files land in the same commit. No `npm install --package-lock-only` — that would re-resolve transitive deps and silently churn the lockfile in a release-prep commit.

2. **`fix(package-lock)`** — the one-time `2.0.0 → 2.1.0-rc.1` cleanup. Exactly two metadata lines change; no dependency tree resolution.

3. **`ci(tests)`** — adds the issue's `jq`-based check to `.github/workflows/tests.yaml` as a fail-fast step placed after `actions/checkout` but before `setup-node-deps`, so a mismatch fails before any node setup cost. The corresponding tag-time gate is the responsibility of the release-validation gating PR.

4. **`docs(contributing)`** — both automated and manual release sections call out the joint bump; manual section also documents the `npm install --package-lock-only` / `npm version` trap.

## Risk verification (done before coding)

- Round-tripping the live 189 KB `package-lock.json` through `JSON.parse` + `JSON.stringify(_, null, 2)` with a preserved trailing newline produces a **byte-identical** file.
- Bumping just the two version fields produces **exactly the 2 intended diff lines** — no key reordering, no whitespace drift, no transitive churn.

## Validation

- `npm ci` succeeds from a clean install on the bumped lockfile.
- `npm audit` reports zero vulnerabilities.
- `npm run lint`, `npm run typecheck`, `npm test` (421/421 passing — 9 new for `bumpPackageLockVersion` and one extended `runCli` integration assertion), `npm run verify:prose-style` all pass.
- `actionlint .github/workflows/tests.yaml` passes.
- The new CI step's failing path was smoke-tested locally with intentionally drifted values and emits the expected `::error::` line.
- Node `24.14.1` (matches `package.json#engines` and `mise.toml`).

## Out of scope (intentional)

- The `release-on-merge.yaml` tag-time check is left for the separate release-validation gating PR per the issue.
- No dependency upgrades.
- No `src/` or `dist/` changes — `git diff --stat HEAD~4 -- src/ dist/` is empty.
- No `CHANGELOG.md` entry — PR carries `release: skip` because the lockfile bump is metadata-only with no consumer-visible behavior change.

## Test plan

- [x] `npm ci`
- [x] `npm audit`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run verify:prose-style`
- [x] `actionlint .github/workflows/tests.yaml`
- [x] Smoke test failing path of new CI step