### PR TITLE
ci: gate release-on-merge tag creation on full validation

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -74,3 +74,9 @@ GitHub App installation tokens expire automatically (one-hour default) and are s
 ### Why an App instead of `GITHUB_TOKEN`
 
 PRs opened by the default `GITHUB_TOKEN` do not trigger downstream workflows (a documented anti-recursion safeguard). Release automation requires that release PRs run their normal CI checks before merging, so the App identity is necessary. PATs are avoided because they tie automation to a person and have broader permission scopes than this use needs.
+
+### Tag-creation gating
+
+`release-on-merge.yaml` is split into a `validate` job and a `tag` job. `validate` runs without the App token (only `contents: read` on `pull_request.merge_commit_sha`) and executes `verify-dist`, `npm run lint`, `npm run typecheck`, `npm test`, the `verify-lockfile-version` composite, and the branch-ref / `package.json` / `CHANGELOG.md` consistency checks. `tag` declares `needs: validate`, mints the App token, and pushes `vX.Y.Z`; a defensive `git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"` check at the top of the tag-push step short-circuits with `exit 0` when the tag already exists, so re-runs do not flap. Both jobs carry the same merged-PR / release-branch guard for defense in depth, and the workflow-level `release-tag` concurrency group continues to serialize the validate→tag sequence and queue concurrent release PRs.
+
+Keeping `validate` token-free means a future change to validation that processes PR-derived content cannot leak App credentials. `release.yaml` is unchanged and continues to run the same validation a second time on tag push as a redundant post-tag defense before the GitHub Release is published.

--- a/.github/actions/verify-lockfile-version/action.yaml
+++ b/.github/actions/verify-lockfile-version/action.yaml
@@ -1,0 +1,20 @@
+name: Verify package-lock.json version matches package.json
+description: Asserts package.json, top-level lockfile version, and lockfile root package version are in sync.
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        PKG="$(jq -r .version package.json)"
+        LOCK_TOP="$(jq -r '.version // empty' package-lock.json)"
+        LOCK_ROOT_PKG="$(jq -r '.packages[""].version // empty' package-lock.json)"
+        if [ -z "${LOCK_TOP}" ] || [ -z "${LOCK_ROOT_PKG}" ]; then
+          echo "::error::package-lock.json is missing required version metadata (top='${LOCK_TOP}' root-pkg='${LOCK_ROOT_PKG}'); lockfileVersion 3 must include both."
+          exit 1
+        fi
+        if [ "${PKG}" != "${LOCK_TOP}" ] || [ "${PKG}" != "${LOCK_ROOT_PKG}" ]; then
+          echo "::error::package.json=${PKG} but package-lock.json reports top=${LOCK_TOP} root-pkg=${LOCK_ROOT_PKG}"
+          exit 1
+        fi

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -13,24 +13,32 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tag:
+  validate:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
-      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        id: app-token
-        with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-node-deps
+
+      - uses: ./.github/actions/verify-dist
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - uses: ./.github/actions/verify-lockfile-version
 
       - name: Validate version consistency
         env:
@@ -49,6 +57,26 @@ jobs:
             exit 1
           fi
 
+  tag:
+    needs: validate
+    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+
       - name: Tag and push
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -56,11 +84,15 @@ jobs:
           BOT_USER_ID: ${{ vars.RELEASE_APP_BOT_USER_ID }}
         run: |
           set -euo pipefail
+          VERSION="${HEAD_REF#release/v}"
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists at origin; nothing to do."
+            exit 0
+          fi
           if [ -z "${BOT_USER_ID}" ]; then
             echo "::error::vars.RELEASE_APP_BOT_USER_ID is empty; refusing to tag with a malformed bot email."
             exit 1
           fi
-          VERSION="${HEAD_REF#release/v}"
           BOT_LOGIN="codex-review-action-release-bot[bot]"
           git config user.name "${BOT_LOGIN}"
           git config user.email "${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,20 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Verify package-lock.json version matches package.json
-        run: |
-          set -euo pipefail
-          PKG="$(jq -r .version package.json)"
-          LOCK_TOP="$(jq -r '.version // empty' package-lock.json)"
-          LOCK_ROOT_PKG="$(jq -r '.packages[""].version // empty' package-lock.json)"
-          if [ -z "${LOCK_TOP}" ] || [ -z "${LOCK_ROOT_PKG}" ]; then
-            echo "::error::package-lock.json is missing required version metadata (top='${LOCK_TOP}' root-pkg='${LOCK_ROOT_PKG}'); lockfileVersion 3 must include both."
-            exit 1
-          fi
-          if [ "${PKG}" != "${LOCK_TOP}" ] || [ "${PKG}" != "${LOCK_ROOT_PKG}" ]; then
-            echo "::error::package.json=${PKG} but package-lock.json reports top=${LOCK_TOP} root-pkg=${LOCK_ROOT_PKG}"
-            exit 1
-          fi
+      - uses: ./.github/actions/verify-lockfile-version
 
       - uses: ./.github/actions/setup-node-deps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ Auto-approval reviews carry the marker body `Auto-approved by the Dependabot Aut
 
 1. Trigger `prepare-release.yaml` via the GitHub UI (`Actions → Prepare Release → Run workflow`). Optionally pass an explicit `version` (e.g. `2.1.0` or `2.1.0-rc.1`); leave empty to compute from the `release: <level>` labels of merged PRs since the last non-pre-release tag.
 2. The workflow opens a PR titled `release: v<X.Y.Z>` against `main` containing the `package.json` bump, the matching `package-lock.json` bump (top-level `version` and `packages[""].version` only — no dependency tree resolution), and the new `CHANGELOG.md` entry, all in the same commit. Review it like any other PR. Re-running the workflow for the same target version updates the existing release branch and PR in place; the bot refuses to force-push if any non-bot commits are present on the release branch.
-3. Squash-merge the release PR. The `release-on-merge.yaml` workflow tags the merge commit with `v<X.Y.Z>` and pushes the tag automatically.
+3. Squash-merge the release PR. The `release-on-merge.yaml` workflow validates the merge commit (lint, typecheck, tests, `verify-dist`, and consistency between the branch ref, `package.json`, `package-lock.json`, and the top `CHANGELOG.md` section), then tags it with `v<X.Y.Z>` and pushes the tag automatically. If validation fails, no tag is created.
 4. The tag push triggers `release.yaml`, which creates the GitHub Release with notes extracted from `CHANGELOG.md`, force-updates the major version tag (skipped for pre-releases), and opens a follow-up PR refreshing SHA-pinned self-references in `README.md` (skipped for pre-releases).
 5. Squash-merge the self-pin refresh PR.
 


### PR DESCRIPTION
## Summary

- Splits `.github/workflows/release-on-merge.yaml` into a `validate` job (no App token, runs `verify-dist`, lint, typecheck, tests, lockfile-version composite, and the existing branch / `package.json` / CHANGELOG consistency checks against `pull_request.merge_commit_sha`) and a `tag` job (depends on `validate`, mints the App token, pushes `vX.Y.Z`). Closes the failure modes called out in #91: required-check drift on `main` can no longer push an invalid tag, and the merge commit is now re-validated at tag time rather than only after the tag fires `release.yaml`.
- Adds a defensive `git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"` check at the top of the tag-push step that exits `0` cleanly if the tag already exists, so re-runs do not flap. Both jobs carry the same merged-PR / `release/v*` guard for defense in depth, and the workflow-level `release-tag` concurrency group continues to serialize the validate→tag sequence.
- Extracts the `package.json` / `package-lock.json` version-sync check into a new `.github/actions/verify-lockfile-version` composite so `tests.yaml` and the new validate job share one definition. `release.yaml` is intentionally unchanged and continues to validate again on tag push as a redundant post-tag defense; `CONTRIBUTING.md` and `.github/SECURITY.md` are updated to describe the new gate.

## Trust boundary impact

None. Internal release-automation hardening; no change to outbound destinations, data sent to OpenAI, telemetry, action permissions, or artifact contents.

## Release label

`release: skip` — internal CI / release-process infra. Workflows under `.github/workflows/` and composites under `.github/actions/` are not part of the published action surface, so adopters do not consume this change.

## Test plan

- [x] `actionlint` (local, plus the SHA-pinned Docker image in CI) on the touched workflows.
- [x] `npm run verify:prose-style` (US English).
- [ ] `npm run lint` (no source touched; expected pass).
- [ ] `npm run typecheck` (no source touched; expected pass).
- [ ] `npm test` (no test files touched; expected pass).
- N/A `npm run build` — CI-config-only; `dist/` cannot change.

## Verification of the gate itself

End-to-end "a failing test on a release branch prevents tag creation" is satisfied by reasoning + the next real release as integration test, because the only ways to actually exercise `pull_request: closed` against a `release/v*` head ref end-to-end are (a) installing the release App on a scratch repo (would contradict the App's documented single-installation invariant in `.github/SECURITY.md`) or (b) merging a fake release PR to `main`. The pieces of the gate that are testable in isolation (`needs:`, lint/typecheck/test/build exit codes, `git ls-remote --exit-code` semantics) are all platform-guaranteed; the composition is reviewed here.

A reusable on-demand verifier and per-PR negative test are tracked separately in #100 so this PR stays scoped to the gate restructure.

## Closes

- Closes #91
- Follow-up: #100 (reusable composite + on-demand verifier)