### PR TITLE
ci: tune dogfood review knobs via repo variables

### DIFF
--- a/.github/workflows/codex-review.yaml
+++ b/.github/workflows/codex-review.yaml
@@ -45,6 +45,7 @@ jobs:
         uses: milanhorvatovic/codex-ai-code-review-action/prepare@0fc55cdd3d5cf9841c9ba58822354f67b6c63293 # v2.1.0-pre
         with:
           allow-users: milanhorvatovic # bounds OpenAI cost while the dogfood is being proven out; revisit after one release cycle
+          max-chunk-bytes: ${{ vars.CODEX_MAX_CHUNK_BYTES || '204800' }}
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: steps.prepare.outputs.skipped != 'true' && steps.prepare.outputs.has-changes == 'true'
@@ -76,6 +77,8 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           chunk: ${{ matrix.chunk }}
+          effort: ${{ vars.CODEX_EFFORT || '' }} # empty = Codex CLI default
+          model: ${{ vars.CODEX_MODEL || '' }} # empty = Codex CLI default
 
   publish:
     needs: [prepare, review]
@@ -102,5 +105,9 @@ jobs:
         with:
           github-token: ${{ github.token }}
           expected-chunks: ${{ needs.prepare.outputs.chunk-count }}
-          retain-findings: "false" # explicit for auditors; matches the action default
+          retain-findings: "true" # retention approved so dogfood findings stay available for ongoing review-quality iteration (CC-07 consent)
+          retain-findings-days: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS || '7' }} # tight window; raise via vars if longer history is needed
+          min-confidence: ${{ vars.CODEX_MIN_CONFIDENCE || '0' }} # 0 = no filtering until tune recommends a cutoff
+          max-comments: ${{ vars.CODEX_MAX_COMMENTS || '' }} # empty = unlimited
+          model: ${{ vars.CODEX_MODEL || '' }} # footer label; pairs with the review job's model
           fail-on-missing-chunks: "true" # pinned SHA includes this input; consumer-controls.md item 8 requires it for v2.1+


### PR DESCRIPTION
## Summary

Adds repository-variable overrides for the dogfood workflow's tuning inputs (`max-chunk-bytes`, `effort`, `model`, `retain-findings-days`, `min-confidence`, `max-comments`) so calibration can iterate without opening a PR. Trust-boundary inputs (`allow-users`, `retain-findings`, `fail-on-missing-chunks`, the three sub-action SHAs) stay literal so a consumer-controls auditor only needs the workflow file.

Flips `retain-findings` from `"false"` to `"true"` with a CC-07 consent comment so dogfood findings stay available for ongoing review-quality iteration. This is the only trust-posture change in this PR — every other input either stays literal or moves to a tuning var that defaults to today's behavior when unset.

## Changes

- `.github/workflows/codex-review.yaml`
  - `prepare` step: adds `max-chunk-bytes: ${{ vars.CODEX_MAX_CHUNK_BYTES || '204800' }}`.
  - `review` step: adds `effort: ${{ vars.CODEX_EFFORT || '' }}` and `model: ${{ vars.CODEX_MODEL || '' }}` (empty string = Codex CLI default).
  - `publish` step: adds `retain-findings-days: ${{ vars.CODEX_RETAIN_FINDINGS_DAYS || '7' }}`, `min-confidence: ${{ vars.CODEX_MIN_CONFIDENCE || '0' }}`, `max-comments: ${{ vars.CODEX_MAX_COMMENTS || '' }}`, and `model: ${{ vars.CODEX_MODEL || '' }}` (footer label).
  - `publish` step: flips `retain-findings: "false"` → `retain-findings: "true"` with a `retention approved so dogfood findings stay available for ongoing review-quality iteration (CC-07 consent)` comment on the same line.

## Trust-boundary stance

What stayed literal and why:

- `allow-users: milanhorvatovic` — policy; visibility matters for audit.
- `retain-findings: "true"` — trust-boundary input; the literal value plus the `retention approved` comment is what CC-07 looks for. Edit-and-commit is the right friction for changing retention posture.
- `fail-on-missing-chunks: "true"` — guardrail per CC-08; literal.
- The three sub-action `@<sha> # v<X.Y.Z>` pins — refreshed via `scripts/refresh-self-pins.ts`, not vars.

Variable naming follows the action's input names directly (e.g., `CODEX_RETAIN_FINDINGS_DAYS` ↔ `retain-findings-days`) so a maintainer can audit the var↔input mapping mechanically.

## Test plan

- [ ] `actionlint` clean on `.github/workflows/codex-review.yaml`
- [ ] Workflow inputs match the pinned SHA's `action.yaml` for each sub-action (verified at `0fc55cdd3d5cf9841c9ba58822354f67b6c63293`: `prepare` accepts `max-chunk-bytes`; `review` accepts `effort`, `model`; `publish` accepts `retain-findings-days`, `min-confidence`, `max-comments`, `model`)
- [ ] Self-test on this PR: `prepare` → `review` → `publish` complete and a Codex review is posted; with no repo variables set, behavior matches the prior dogfood run except findings are retained for 7 days

## Sequencing

Depends on `#107` (dogfood workflow landed) and `#102` (production docs at v2.1.0). Both are on `main`.