### PR TITLE
fix: stop SHA-only self-bumps from blocking Dependabot auto-merge

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,11 @@ updates:
     package-ecosystem: "github-actions"
     groups:
       github-actions:
+        exclude-patterns:
+          # Keep the dogfood self-reference out of the third-party group: it bumps
+          # SHA→SHA under the same `v2.1.0-pre` tag, which dependabot/fetch-metadata
+          # classifies as semver-major and otherwise poisons the grouped update-type.
+          - "milanhorvatovic/codex-ai-code-review-action"
         patterns:
           - "*"
     labels:

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -118,6 +118,30 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # `steps.metadata.outputs.update-type` is the most-severe per-dep type across the group.
+      # The dogfood self-reference bumps SHA→SHA under the same prerelease tag, which
+      # fetch-metadata conservatively reports as semver-major. Treating that as "major" for
+      # gating purposes blocks otherwise-safe grouped patches and standalone self-bumps. We
+      # walk the per-dep JSON instead and only escalate to "major" when a *third-party* dep is
+      # genuinely a major bump.
+      - name: Derive effective update-type
+        id: effective
+        env:
+          UPDATED_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
+        run: |
+          set -euo pipefail
+          third_party_major=$(jq -r '
+            any(.[];
+              .updateType == "version-update:semver-major"
+              and .dependencyName != "milanhorvatovic/codex-ai-code-review-action"
+            )
+          ' <<<"$UPDATED_JSON")
+          if [ "$third_party_major" = "true" ]; then
+            echo "update-type=version-update:semver-major" >> "$GITHUB_OUTPUT"
+          else
+            echo "update-type=version-update:semver-patch" >> "$GITHUB_OUTPUT"
+          fi
+
       # See CONTRIBUTING.md → Trust-boundary changes for the policy.
       # Two guards coexist intentionally:
       #   1. Exclude-by-name: skip auto-merge for any (possibly grouped) bump that includes
@@ -139,7 +163,7 @@ jobs:
       # and the PR waits for manual approval, matching the prior behavior.
       - name: Approve PR (so required-review check passes)
         if: >-
-          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          steps.effective.outputs.update-type != 'version-update:semver-major'
           && !contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')
           && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
         env:
@@ -179,7 +203,7 @@ jobs:
 
       - name: Auto-merge patch and minor updates
         if: >-
-          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          steps.effective.outputs.update-type != 'version-update:semver-major'
           && !contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')
           && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
         env:

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -121,26 +121,31 @@ jobs:
       # `steps.metadata.outputs.update-type` is the most-severe per-dep type across the group.
       # The dogfood self-reference bumps SHA→SHA under the same prerelease tag, which
       # fetch-metadata conservatively reports as semver-major. Treating that as "major" for
-      # gating purposes blocks otherwise-safe grouped patches and standalone self-bumps. We
-      # walk the per-dep JSON instead and only escalate to "major" when a *third-party* dep is
-      # genuinely a major bump.
+      # gating purposes blocks otherwise-safe grouped patches and standalone self-bumps.
+      #
+      # Walk `updated-dependencies-json` instead and pick the most-severe update-type after
+      # excluding the self-reference *only* when its bump is SHA-only same-version
+      # (`prevVersion == newVersion`). Real major bumps of the self-reference still classify
+      # as semver-major and route to manual review. The self-reference is identified via
+      # `github.repository` so a rename/transfer/fork picks up the new name automatically.
       - name: Derive effective update-type
         id: effective
         env:
+          SELF_DEPENDENCY: ${{ github.repository }}
           UPDATED_JSON: ${{ steps.metadata.outputs.updated-dependencies-json }}
         run: |
           set -euo pipefail
-          third_party_major=$(jq -r '
-            any(.[];
-              .updateType == "version-update:semver-major"
-              and .dependencyName != "milanhorvatovic/codex-ai-code-review-action"
-            )
+          effective=$(jq -r --arg self "$SELF_DEPENDENCY" '
+            [.[]
+              | select(.dependencyName != $self or .prevVersion != .newVersion)
+              | .updateType]
+            | if any(. == "version-update:semver-major") then "version-update:semver-major"
+              elif any(. == "version-update:semver-minor") then "version-update:semver-minor"
+              elif any(. == "version-update:semver-patch") then "version-update:semver-patch"
+              else "version-update:semver-patch"
+              end
           ' <<<"$UPDATED_JSON")
-          if [ "$third_party_major" = "true" ]; then
-            echo "update-type=version-update:semver-major" >> "$GITHUB_OUTPUT"
-          else
-            echo "update-type=version-update:semver-patch" >> "$GITHUB_OUTPUT"
-          fi
+          echo "update-type=$effective" >> "$GITHUB_OUTPUT"
 
       # See CONTRIBUTING.md → Trust-boundary changes for the policy.
       # Two guards coexist intentionally:


### PR DESCRIPTION
## Summary

The Dependabot Auto-Merge workflow stopped firing for grouped GitHub Actions bumps (e.g. #112). Root cause: `dependabot/fetch-metadata` reports the *most-severe* per-dependency `update-type` for the whole group. The dogfood self-reference (`milanhorvatovic/codex-ai-code-review-action`) bumps SHA→SHA under the same `v2.1.0-pre` prerelease tag, which fetch-metadata conservatively classifies as `version-update:semver-major`. That single classification poisons the aggregate, the guard skips the approve/auto-merge steps, and otherwise-clean third-party patches sit waiting for manual review.

This PR fixes both layers:

- **`chore(dependabot)`** — exclude the self-reference from the `github-actions` group in `.github/dependabot.yaml`. Third-party Action patches stay grouped and auto-mergeable; the self-reference arrives as its own ungrouped PR.
- **`ci(dependabot-auto-merge)`** — derive an effective update-type from `updated-dependencies-json` per-dependency metadata. The guard only escalates to "major" when a third-party dep is genuinely a major bump. Defense in depth alongside the config change.

The existing `openai/codex-action` denylist and `trust-boundary` label guard are unchanged.

## Test plan

- [x] `actionlint` passes locally on the modified workflow (verified)
- [ ] Once merged, comment `@dependabot recreate` on #112 — the codeql patch should split out and auto-merge
- [ ] Next Monday's Dependabot run produces a separate ungrouped PR for any self-reference SHA bump