### PR TITLE
docs: extend security-review policy to containment-mechanism surfaces

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,20 +2,30 @@
 
 <!-- 1-3 bullets on what changed and why. -->
 
-## Trust boundary impact
+## Security-review impact
 
 <!--
-  Does this PR change any of the following? If yes, label the PR `trust-boundary`
-  and describe the impact below. If no, leave "None." and delete this comment.
+  Does this PR change any of the surfaces below? If yes, label the PR with the
+  matching class (`trust-boundary`, `security-review-required`, or both) and
+  describe the impact below. If no, leave "None." and delete this comment.
 
-  - outbound HTTP destination
-  - data sent to OpenAI
-  - telemetry / logging that leaves the runner
-  - permissions required by the action
-  - artifact contents
-  - transitive dependency SHA that changes any of the above
+  Trust-boundary surfaces (what data crosses what boundary — label `trust-boundary`):
+    - outbound HTTP destination
+    - data sent to OpenAI
+    - telemetry / logging that leaves the runner
+    - permissions required by the action
+    - artifact contents
+    - default exit-code contract
+    - transitive dependency SHA that changes any of the above
 
-  See CONTRIBUTING.md → Trust-boundary changes for the full criteria.
+  Containment-mechanism surfaces (how those boundaries stay enforced — label `security-review-required`):
+    - event trigger surface (especially adding/expanding `pull_request_target`)
+    - secret scoping, passing, naming, or job exposure
+    - model-execution sandboxing (e.g. `openai/codex-action` `sandbox:` input)
+    - `review-reference-file` / `review-reference-source` validation, resolution, or sourcing
+    - workflow job-boundary moves between `prepare` / `review` / `publish`
+
+  See CONTRIBUTING.md → Security-review-required changes for the full criteria.
 -->
 
 None.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -11,6 +11,30 @@
 
 PR diffs and metadata leave the runner only via two destinations: **GitHub** (PR context, posting the review, artifact storage) and **OpenAI** (via the SHA-pinned [`openai/codex-action`](https://github.com/openai/codex-action) invoked from `review/action.yaml`). This repository operates no maintainer-owned backend, proxy, analytics service, or telemetry pipeline that receives diffs. See the [Trust model](../README.md#trust-model) section in the README for the full statement.
 
+## Reviewing security-relevant changes
+
+Maintainers gate two complementary classes of change behind explicit security review and dedicated CHANGELOG callouts so adopters who have already hardened their workflow can re-audit before pulling a new SHA.
+
+**Trust-boundary changes** — *what* data crosses what boundary:
+
+- outbound HTTP destinations (any new host or external API call);
+- data sent to OpenAI via the prompt (new fields, larger excerpts, new metadata);
+- analytics, logging, or telemetry that leaves the GitHub Actions runner;
+- `permissions:` required by the action (new scope, new token usage);
+- artifact contents that change what callers must trust;
+- default exit-code contract (a scenario the action previously exited 0 on now exits non-zero, or vice versa);
+- transitive dependency SHA flips that touch any of the above (notably `openai/codex-action`).
+
+**Containment-mechanism changes** — *how* those boundaries stay enforced:
+
+- event trigger surface, especially adding or expanding `pull_request_target`, `workflow_run`, or `issue_comment` (the existing `pull_request` trigger is the safe baseline);
+- secret scoping, passing, naming, or job-level exposure;
+- model-execution sandboxing, including any `openai/codex-action` input that controls network access, filesystem access, or process execution under the model;
+- `review-reference-file` and `review-reference-source` validation, resolution, or sourcing;
+- workflow job-boundary moves between `prepare`, `review`, and `publish` that cross a permission or secret scope.
+
+PRs in either class carry the matching label (`trust-boundary`, `security-review-required`, or both), get a dedicated CHANGELOG callout at release time, and require maintainer security-review sign-off recorded against the release gate. The full criteria, label rules, Dependabot enforcement, and CHANGELOG callout shapes live in [`CONTRIBUTING.md` → Security-review-required changes](../CONTRIBUTING.md#security-review-required-changes); this section is the auditor-facing summary.
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in this project, please report it responsibly:

--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -59,7 +59,7 @@ The `review` action is a composite wrapper around `openai/codex-action` and has 
 
 ## Pull request authoring
 
-- PR descriptions follow [`.github/PULL_REQUEST_TEMPLATE.md`](../PULL_REQUEST_TEMPLATE.md): `## Summary`, `## Trust boundary impact`, `## Test plan`.
-- Fill every section. If the PR does not change a trust boundary, leave `None.` in that section rather than deleting the heading.
-- Apply the `trust-boundary` label when the Trust boundary impact section describes a real change.
-- See [`CONTRIBUTING.md` → Trust-boundary changes](../../CONTRIBUTING.md#trust-boundary-changes) for the criteria and the maintainer-side review process.
+- PR descriptions follow [`.github/PULL_REQUEST_TEMPLATE.md`](../PULL_REQUEST_TEMPLATE.md): `## Summary`, `## Security-review impact`, `## Release label`, `## Test plan`.
+- Fill every section. If the PR does not affect any trust-boundary or containment-mechanism surface, leave `None.` in the Security-review impact section rather than deleting the heading.
+- Apply the `trust-boundary` label when the change touches a trust-boundary surface, the `security-review-required` label when it touches a containment-mechanism surface, or both when it touches both.
+- See [`CONTRIBUTING.md` → Security-review-required changes](../../CONTRIBUTING.md#security-review-required-changes) for the criteria and the maintainer-side review process.

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -18,17 +18,17 @@ permissions:
 # already-merged PR).
 #
 # `cancel-in-progress` is conditional. We cancel for `opened`/`reopened`/`synchronize`
-# (the new event has fresher PR state to merge against) and for the `trust-boundary`
-# labeled event (which means "stop the merge now"). We do NOT cancel for non-trust-
-# boundary `labeled` events: Dependabot adds `dependencies`/`release: patch`/etc. labels
-# in rapid succession right after opening a PR, and those replacement runs skip both
-# `rebuild-dist` and `auto-merge` per their `if:` guards — so canceling the in-flight
-# merge run for them would leave the PR stranded with neither a synchronous merge nor
-# auto-merge enabled. Letting them queue behind the in-flight run is harmless (they're
-# no-ops on the merge path) and avoids the stall.
+# (the new event has fresher PR state to merge against) and for either security-review
+# `labeled` event (`trust-boundary` or `security-review-required`, both meaning "stop the
+# merge now"). We do NOT cancel for non-security-review `labeled` events: Dependabot adds
+# `dependencies`/`release: patch`/etc. labels in rapid succession right after opening a
+# PR, and those replacement runs skip both `rebuild-dist` and `auto-merge` per their `if:`
+# guards — so canceling the in-flight merge run for them would leave the PR stranded with
+# neither a synchronous merge nor auto-merge enabled. Letting them queue behind the
+# in-flight run is harmless (they're no-ops on the merge path) and avoids the stall.
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'trust-boundary' }}
+  cancel-in-progress: ${{ github.event.action != 'labeled' || github.event.label.name == 'trust-boundary' || github.event.label.name == 'security-review-required' }}
 
 jobs:
   rebuild-dist:
@@ -118,8 +118,9 @@ jobs:
 
   auto-merge:
     # Skip on label events — auto-merge is set once at open/synchronize time. If a maintainer later
-    # applies the trust-boundary label, the disable-auto-merge-on-trust-boundary job below handles
-    # revoking the previously-enabled auto-merge.
+    # applies either security-review label (trust-boundary or security-review-required), the
+    # disable-auto-merge-on-security-review job below handles revoking the previously-enabled
+    # auto-merge.
     if: >-
       github.event.action != 'labeled' &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
@@ -179,13 +180,18 @@ jobs:
           ' <<<"$UPDATED_JSON")
           echo "update-type=$effective" >> "$GITHUB_OUTPUT"
 
-      # See CONTRIBUTING.md → Trust-boundary changes for the policy.
+      # See CONTRIBUTING.md → Security-review-required changes for the policy.
       # Two guards coexist intentionally:
       #   1. Exclude-by-name: skip auto-merge for any (possibly grouped) bump that includes
-      #      `openai/codex-action`. Extend this list when a new trust-boundary dependency
+      #      `openai/codex-action`. The exclude list is intentionally action-level
+      #      dependencies only — packages whose code runs inside the workflow with secrets
+      #      in scope. Passive deps (e.g. `actions/checkout`) are not on the list because
+      #      their bumps are caught by the criteria-based label guards. Extend this list
+      #      when a new action-level trust-boundary or containment-mechanism dependency
       #      is added to the repo.
       #   2. Label guard: skip auto-merge for any PR a maintainer has manually labeled
-      #      `trust-boundary`, even if the dep is not yet on the exclude list.
+      #      `trust-boundary` or `security-review-required`, even if the dep is not yet
+      #      on the exclude list.
       # The `if:` clauses below evaluate against the event payload captured at workflow start.
       # That payload can be stale by the time this step runs (label applied during the run).
       # The runtime checks inside `run:` close that TOCTOU race — see the comments there.
@@ -203,6 +209,7 @@ jobs:
           steps.effective.outputs.update-type != 'version-update:semver-major'
           && !contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')
           && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
+          && !contains(github.event.pull_request.labels.*.name, 'security-review-required')
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVE_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -227,15 +234,15 @@ jobs:
             echo "::warning::DEPENDABOT_APPROVE_TOKEN is not set — skipping auto-approval. The merge step will fall back to GitHub auto-merge, which waits for a manual code-owner approval. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and store it under Settings → Secrets and variables → Dependabot → DEPENDABOT_APPROVE_TOKEN."
             exit 0
           fi
-          if ! label_state=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary")'); then
-            echo "::warning::Failed to query trust-boundary label state; skipping auto-approval. The merge step will fall back to GitHub auto-merge."
+          if ! label_state=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary" or .name == "security-review-required")'); then
+            echo "::warning::Failed to query security-review label state; skipping auto-approval. The merge step will fall back to GitHub auto-merge."
             exit 0
           fi
           if [ "$label_state" = "true" ]; then
-            echo "trust-boundary label is now present (applied after workflow start); skipping auto-approval."
+            echo "security-review label (trust-boundary or security-review-required) is now present (applied after workflow start); skipping auto-approval."
             exit 0
           fi
-          if ! gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, non-trust-boundary update)." "$PR_URL"; then
+          if ! gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, no security-review label)." "$PR_URL"; then
             echo "::warning::Failed to post auto-approval review (likely a revoked or insufficiently-scoped DEPENDABOT_APPROVE_TOKEN, or a transient GitHub API error). The merge step will fall back to GitHub auto-merge."
             exit 0
           fi
@@ -255,49 +262,54 @@ jobs:
       #      approval step exited 0: if `DEPENDABOT_APPROVE_TOKEN` belongs to a non-CODEOWNER
       #      identity, `gh pr review --approve` succeeds but `reviewDecision` stays
       #      `REVIEW_REQUIRED` and we correctly fall back instead of failing on the merge.
-      #   2. Fail-closed label query. The trust-boundary label is queried via a tri-state
-      #      helper that returns `unknown` on `gh pr view` errors. Pre- and post-poll
-      #      `unknown` exits the job with `::error::` rather than arming auto-merge: if
-      #      the label was actually present and the reactive disable job already ran, an
-      #      armed auto-merge here cannot be backstopped. The same fail-closed treatment
-      #      runs after `arm_auto_merge` enables auto-merge — `unknown` triggers a
-      #      defensive `gh pr merge --disable-auto` and a non-zero return.
+      #   2. Fail-closed label query. Both security-review labels (trust-boundary,
+      #      security-review-required) are queried together via a tri-state helper that
+      #      returns `unknown` on `gh pr view` errors. Pre- and post-poll `unknown` exits
+      #      the job with `::error::` rather than arming auto-merge: if either label was
+      #      actually present and the reactive disable job already ran, an armed auto-merge
+      #      here cannot be backstopped. The same fail-closed treatment runs after
+      #      `arm_auto_merge` enables auto-merge — `unknown` triggers a defensive
+      #      `gh pr merge --disable-auto` and a non-zero return.
       #   3. Concurrency-safe. Workflow-level concurrency cancels overlapping runs on the
       #      same PR, so the `gh pr checks --watch` loop here is interrupted cleanly when
       #      a new commit lands rather than racing a fresh run.
       #
-      # Trust-boundary handling: the label is re-checked twice on the synchronous path —
-      # once before polling (so we don't waste minutes waiting on a PR we won't merge) and
-      # again immediately before the merge (closing the race where a maintainer applies the
-      # label while checks run). The fallback path keeps the original post-enable revert.
+      # Security-review handling: the label state is re-checked twice on the synchronous
+      # path — once before polling (so we don't waste minutes waiting on a PR we won't
+      # merge) and again immediately before the merge (closing the race where a maintainer
+      # applies a label while checks run). The fallback path keeps the original post-enable
+      # revert.
       #
       # A residual TOCTOU window remains on the synchronous path — between the second
       # label re-check and `gh pr merge --squash`, a few milliseconds of inter-command
       # latency. This is no worse than the prior `--auto` design's window between auto-
       # merge enable and the reactive `--disable-auto` revert. Closing it atomically
-      # requires elevating the trust-boundary policy to a required status check so the
+      # requires elevating the security-review policy to a required status check so the
       # ruleset itself refuses the merge — left as future work.
       - name: Wait for required checks, then squash-merge
         if: >-
           steps.effective.outputs.update-type != 'version-update:semver-major'
           && !contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')
           && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
+          && !contains(github.event.pull_request.labels.*.name, 'security-review-required')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           set -euo pipefail
 
-          # Tri-state trust-boundary label query.  Returns "true" / "false" on a successful
-          # gh response and "unknown" if the API call fails (rate limit, network, 5xx).
-          # Callers handle "unknown" by failing closed — see the helper-level comments
-          # below for the policy reasoning. Stderr is intentionally NOT redirected so the
-          # underlying gh failure (auth, rate limit, transient 5xx) lands in the workflow
-          # log; the downstream `unknown` error messages tell maintainers to investigate
-          # that output.
-          trust_boundary_state() {
+          # Tri-state security-review label query. Returns "true" / "false" on a
+          # successful gh response and "unknown" if the API call fails (rate limit,
+          # network, 5xx). "true" means at least one of the two security-review labels
+          # (`trust-boundary`, `security-review-required`) is present; either label
+          # blocks auto-merge identically. Callers handle "unknown" by failing closed
+          # — see the helper-level comments below for the policy reasoning. Stderr is
+          # intentionally NOT redirected so the underlying gh failure (auth, rate limit,
+          # transient 5xx) lands in the workflow log; the downstream `unknown` error
+          # messages tell maintainers to investigate that output.
+          security_review_state() {
             local result
-            if ! result=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary")'); then
+            if ! result=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary" or .name == "security-review-required")'); then
               echo "unknown"
               return
             fi
@@ -335,10 +347,10 @@ jobs:
             esac
           }
 
-          # Enable GitHub auto-merge, verify the call took, and revert it if the
-          # trust-boundary label is now present (or its state has become unknown).
+          # Enable GitHub auto-merge, verify the call took, and revert it if either
+          # security-review label is now present (or its state has become unknown).
           # Returns 0 on full success, 1 on any verification or revert failure (with
-          # appropriate `::error::` annotations). Disable-auto on a trust-boundary PR
+          # appropriate `::error::` annotations). Disable-auto on a security-review PR
           # is a hard failure: silently logging it as a warning would let auto-merge
           # stay armed on a PR the policy says must remain manual, which is a worse
           # outcome than a noisy workflow failure. Same fail-closed treatment for the
@@ -349,18 +361,18 @@ jobs:
             if ! verify_auto_merge_or_terminal; then
               return 1
             fi
-            case "$(trust_boundary_state)" in
+            case "$(security_review_state)" in
               true)
-                echo "trust-boundary label is now present; reverting auto-merge."
+                echo "security-review label (trust-boundary or security-review-required) is now present; reverting auto-merge."
                 if ! gh pr merge --disable-auto "$PR_URL"; then
-                  echo "::error::Failed to disable auto-merge on a trust-boundary PR. The PR may still merge automatically when conditions are met, bypassing the policy that requires manual maintainer review. Investigate immediately."
+                  echo "::error::Failed to disable auto-merge on a security-review PR. The PR may still merge automatically when conditions are met, bypassing the policy that requires manual maintainer review. Investigate immediately."
                   return 1
                 fi
                 return 1 ;;
               unknown)
-                echo "::error::Failed to verify trust-boundary state after arming auto-merge. Defensively disabling auto-merge to avoid a possible policy bypass — if the label is actually present, we cannot rely on the reactive disable job to backstop us (it only fires on the labeled event, which may have already run before this point)."
+                echo "::error::Failed to verify security-review label state after arming auto-merge. Defensively disabling auto-merge to avoid a possible policy bypass — if a security-review label is actually present, we cannot rely on the reactive disable job to backstop us (it only fires on the labeled event, which may have already run before this point)."
                 if ! gh pr merge --disable-auto "$PR_URL"; then
-                  echo "::error::Failed to defensively disable auto-merge on a possibly-trust-boundary PR. Investigate immediately."
+                  echo "::error::Failed to defensively disable auto-merge on a possibly security-review-required PR. Investigate immediately."
                 fi
                 return 1 ;;
             esac
@@ -369,29 +381,29 @@ jobs:
 
           # Used by the unhappy paths (review not APPROVED, label state unknown). Enables
           # auto-merge as a graceful fallback so a later code-owner approval can finish the
-          # merge; the reactive disable-auto-merge-on-trust-boundary job below remains a
-          # backstop for trust-boundary applications that land after this point.
+          # merge; the reactive disable-auto-merge-on-security-review job below remains a
+          # backstop for security-review label applications that land after this point.
           fall_back_to_auto_merge() {
-            echo "::warning::$1; enabling GitHub auto-merge so a later code-owner approval (and/or the reactive disable-auto-merge job for trust-boundary) can finish or halt the merge."
+            echo "::warning::$1; enabling GitHub auto-merge so a later code-owner approval (and/or the reactive disable-auto-merge job for security-review labels) can finish or halt the merge."
             if ! arm_auto_merge; then
               exit 1
             fi
             exit 0
           }
 
-          # Pre-poll trust-boundary check. `unknown` fails closed: if we can't see the
-          # label state and it's actually present, the reactive disable-auto-merge job
-          # may have already run on the labeled event before we reach here — arming
-          # auto-merge with `fall_back_to_auto_merge` would leave it active on a PR the
-          # policy says must be manual. A workflow failure is recoverable via re-run; a
-          # silent policy bypass isn't.
-          case "$(trust_boundary_state)" in
+          # Pre-poll security-review check. `unknown` fails closed: if we can't see the
+          # label state and a security-review label is actually present, the reactive
+          # disable-auto-merge job may have already run on the labeled event before we
+          # reach here — arming auto-merge with `fall_back_to_auto_merge` would leave it
+          # active on a PR the policy says must be manual. A workflow failure is
+          # recoverable via re-run; a silent policy bypass isn't.
+          case "$(security_review_state)" in
             true)
-              echo "trust-boundary label is now present (applied after workflow start); skipping merge."
+              echo "security-review label (trust-boundary or security-review-required) is now present (applied after workflow start); skipping merge."
               exit 0
               ;;
             unknown)
-              echo "::error::Failed to query trust-boundary label state pre-poll. Refusing to arm auto-merge: if the label is actually present, the reactive disable-auto-merge-on-trust-boundary job may have already run before we'd arm auto-merge here, leaving an unrevoked merge on a PR the policy says must be manual. Investigate the gh pr view error above and re-run."
+              echo "::error::Failed to query security-review label state pre-poll. Refusing to arm auto-merge: if a security-review label is actually present, the reactive disable-auto-merge-on-security-review job may have already run before we'd arm auto-merge here, leaving an unrevoked merge on a PR the policy says must be manual. Investigate the gh pr view error above and re-run."
               exit 1
               ;;
           esac
@@ -414,15 +426,15 @@ jobs:
             exit 1
           fi
 
-          # Post-poll trust-boundary re-check. Same fail-closed treatment as the pre-poll
+          # Post-poll security-review re-check. Same fail-closed treatment as the pre-poll
           # check — see the comment there for the policy-bypass reasoning.
-          case "$(trust_boundary_state)" in
+          case "$(security_review_state)" in
             true)
-              echo "trust-boundary label was applied while waiting for checks; skipping merge."
+              echo "security-review label (trust-boundary or security-review-required) was applied while waiting for checks; skipping merge."
               exit 0
               ;;
             unknown)
-              echo "::error::Failed to query trust-boundary label state post-poll. Refusing to arm auto-merge: see the pre-poll comment above for why a possibly-present trust-boundary label cannot be safely backstopped from this point. Investigate the gh pr view error above and re-run."
+              echo "::error::Failed to query security-review label state post-poll. Refusing to arm auto-merge: see the pre-poll comment above for why a possibly-present security-review label cannot be safely backstopped from this point. Investigate the gh pr view error above and re-run."
               exit 1
               ;;
           esac
@@ -449,21 +461,22 @@ jobs:
             fall_back_to_auto_merge "Synchronous squash merge failed (mergeability may have changed since the check wait completed — base branch advanced, transient API error, or branch is BEHIND)"
           fi
 
-  # Reactive disable: if a maintainer applies the `trust-boundary` label after auto-merge has
-  # already been enabled by the auto-merge job above, the label-guard `if:` on that step only
-  # prevents re-enabling — it does not revoke a previously-enabled auto-merge. This job runs on
-  # the `labeled` pull_request event and explicitly disables auto-merge so the PR stays open
-  # for manual maintainer review and merging.
+  # Reactive disable: if a maintainer applies either security-review label
+  # (`trust-boundary` or `security-review-required`) after auto-merge has already been
+  # enabled by the auto-merge job above, the label-guard `if:` on that step only prevents
+  # re-enabling — it does not revoke a previously-enabled auto-merge. This job runs on
+  # the `labeled` pull_request event and explicitly disables auto-merge so the PR stays
+  # open for manual maintainer review and merging.
   #
   # A previously-posted auto-approval review (from the approve step above) is intentionally
   # left in place. Disabling auto-merge is sufficient to stop the automatic merge; the
   # ruleset's `dismiss_stale_reviews_on_push: true` will clear the bot review on the next push,
   # and the maintainer who applied the label can dismiss it manually if they want a clean
   # review state before re-evaluating.
-  disable-auto-merge-on-trust-boundary:
+  disable-auto-merge-on-security-review:
     if: >-
       github.event.action == 'labeled' &&
-      github.event.label.name == 'trust-boundary' &&
+      (github.event.label.name == 'trust-boundary' || github.event.label.name == 'security-review-required') &&
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,9 +124,22 @@ To run the same lint locally, pick whichever path fits your platform:
 
 - **Native package managers.** macOS: `brew install actionlint shellcheck`. Linux: install `shellcheck` from your distro and `actionlint` from the [upstream releases](https://github.com/rhysd/actionlint/releases). Windows: `scoop install actionlint shellcheck`.
 
-## Trust-boundary changes
+## Security-review-required changes
 
-Changes that affect data destinations, forwarding, telemetry, auth scopes, or what callers must trust require explicit release-note treatment so adopters who have already hardened their workflow can re-review.
+Changes that affect what data crosses the action's trust boundaries, or the runtime structure that keeps those boundaries enforced, require explicit security review and dedicated release-note treatment so adopters who have already hardened their workflow can re-review.
+
+The policy covers two complementary classes:
+
+- **Trust-boundary changes** — changes to *what* data crosses what boundary (data destinations, prompt contents, telemetry, permission scopes, artifact contents, exit-code contract, transitive dep flips touching any of these).
+- **Containment-mechanism changes** — changes to *how* those boundaries stay enforced (event triggers, secret scoping, model-execution sandboxing, reference-file behavior, workflow job-boundary moves).
+
+Each class has its own label and CHANGELOG callout; both feed the same Dependabot enforcement and release-gate sign-off discipline. The label names predate the umbrella section name and are kept stable for automation and search.
+
+When in doubt, treat the change as security-review-required and apply the label that fits best (or both). A PR may carry both labels if it touches both classes; both callouts then appear in the CHANGELOG.
+
+This applies to every PR regardless of author — maintainer, outside contributor, or AI-assisted — including Dependabot PRs that bump a transitive SHA falling under the criteria below. Maintainers apply the label on Dependabot's behalf during review.
+
+### Trust-boundary changes
 
 A change is trust-boundary-affecting if it:
 
@@ -138,29 +151,41 @@ A change is trust-boundary-affecting if it:
 - changes the default exit-code contract — a scenario the action previously exited 0 on now exits non-zero (or vice versa), including via a default-input flip;
 - updates a transitive dependency that itself changes any of the above (e.g. updating the `openai/codex-action` SHA pin in `review/action.yaml`).
 
-When in doubt, treat the change as trust-boundary-affecting.
+PRs in this class:
 
-PRs with such changes must:
+- carry the `trust-boundary` label;
+- include a `## Security-review impact` paragraph in the PR description (see [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md));
+- get a `### ⚠️ Trust boundary change` CHANGELOG callout at release time (see [Release process](#release-process) step 2b).
 
-- be labeled `trust-boundary`;
-- include a "Trust boundary impact" paragraph in the PR description (see [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md));
-- get a dedicated CHANGELOG callout at release time (see [Release process](#release-process) step 2b).
+### Containment-mechanism changes
 
-This applies to every PR regardless of author — maintainer, outside contributor, or AI-assisted — including Dependabot PRs that bump a transitive SHA falling under the criteria above. Maintainers apply the label on Dependabot's behalf during review.
+A change is containment-mechanism-affecting if it:
+
+- adds or expands a workflow event trigger that runs the workflow with secrets in scope against PR-controlled content (notably `pull_request_target`, `workflow_run`, or `issue_comment`). The existing `pull_request` trigger is the safe baseline and is unchanged unless explicitly noted.
+- changes how secrets are scoped, passed, named, or exposed to jobs — for example, moving a secret between environment-scoped and repo-scoped, renaming a secret, adding a job that receives a secret it did not previously receive, or widening which steps within a job see it via `env:`.
+- alters model-execution sandboxing, including any `openai/codex-action` input that controls network access, filesystem access, or process execution under the model (today `sandbox: read-only` at [`review/action.yaml`](review/action.yaml)).
+- changes the validation, resolution, or sourcing of `review-reference-file` or `review-reference-source` — for example, the path-validation rules in [`src/prepare/referenceFile.ts`](src/prepare/referenceFile.ts) or the base-mode resolution tracked in [issue #97](https://github.com/milanhorvatovic/codex-ai-code-review-action/issues/97). A change that *adds new content paths into the prompt itself* belongs in the trust-boundary class above; a change to *how an existing input is validated or sourced* belongs here.
+- moves prompt assembly, model execution, or PR publishing across the existing `prepare` / `review` / `publish` job-boundary. Today: `prepare` carries no API key with `contents: read`; `review` carries the API key with `contents: read`; `publish` carries no API key with `contents: read` plus `pull-requests: write`. Any change that crosses these scopes belongs here.
+
+PRs in this class:
+
+- carry the `security-review-required` label;
+- include a `## Security-review impact` paragraph in the PR description (see [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md));
+- get a `### 🔒 Containment-mechanism change` CHANGELOG callout at release time (see [Release process](#release-process) step 2b).
 
 ### Dependabot enforcement
 
-The auto-merge workflow at [`.github/workflows/dependabot-auto-merge.yaml`](.github/workflows/dependabot-auto-merge.yaml) carries three layers of enforcement:
+The auto-merge workflow at [`.github/workflows/dependabot-auto-merge.yaml`](.github/workflows/dependabot-auto-merge.yaml) carries three layers of enforcement, each gated on either of the two security-review labels (`trust-boundary`, `security-review-required`):
 
-- **Exclude-by-name guard** in the auto-merge step's `if:` expression: `!contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')` — auto-merge is never enabled for any (possibly grouped) Dependabot PR that includes `openai/codex-action`. Extend this clause when a new trust-boundary dependency is added to the repo.
-- **Label guard** — fast-path `if:` clause `!contains(github.event.pull_request.labels.*.name, 'trust-boundary')` plus runtime re-checks inside the auto-merge step. The `if:` evaluates against the event payload captured at workflow start, which can be stale by the time the step runs; the runtime pre-check (`gh pr view --json labels`) bails out if the label is now present, and a runtime post-check after `gh pr merge --auto` reverts the enable if the label was applied during the brief enable window. Both checks together close the TOCTOU race that the `if:` alone cannot.
-- **Reactive disable job** triggered on the `labeled` pull_request event: if a maintainer applies the `trust-boundary` label *after* auto-merge has already been enabled and committed (i.e., outside the runtime post-check window above), the `disable-auto-merge-on-trust-boundary` job runs `gh pr merge --disable-auto` to revoke it.
+- **Exclude-by-name guard** in the auto-merge step's `if:` expression: `!contains(steps.metadata.outputs.dependency-names, 'openai/codex-action')` — auto-merge is never enabled for any (possibly grouped) Dependabot PR that includes `openai/codex-action`. The exclude list is intentionally action-level dependencies only — packages whose code runs inside the workflow with secrets in scope. Passive deps (e.g. `actions/checkout`) are not on the list because their bumps are handled by the criteria-based label guards. Extend this clause when a new action-level trust-boundary or containment-mechanism dependency is added to the repo.
+- **Label guard** — fast-path `if:` clauses that exclude both `trust-boundary` and `security-review-required` from the labels payload, plus runtime re-checks inside the auto-merge step. The `if:` evaluates against the event payload captured at workflow start, which can be stale by the time the step runs; the runtime pre-check (`gh pr view --json labels`) bails out if either label is now present, and a runtime post-check after `gh pr merge --auto` reverts the enable if either label was applied during the brief enable window. Both checks together close the TOCTOU race that the `if:` alone cannot.
+- **Reactive disable job** triggered on the `labeled` pull_request event: if a maintainer applies either security-review label *after* auto-merge has already been enabled and committed (i.e., outside the runtime post-check window above), the `disable-auto-merge-on-security-review` job runs `gh pr merge --disable-auto` to revoke it.
 
-All three coexist intentionally. The exclude list is the declarative defense (fail-closed for known dependencies); the label guard's runtime checks close the TOCTOU race during the auto-merge step itself; the reactive disable job catches PRs labeled later in the PR's lifecycle. Removing any layer weakens the policy.
+All three coexist intentionally. The exclude list is the declarative defense (fail-closed for known action-level dependencies); the label guard's runtime checks close the TOCTOU race during the auto-merge step itself; the reactive disable job catches PRs labeled later in the PR's lifecycle. Removing any layer weakens the policy.
 
 #### Auto-approval
 
-The default-branch ruleset on `main` requires one approving code-owner review before merge. `GITHUB_TOKEN` cannot approve PRs and Dependabot cannot approve its own PRs, so without an additional approver auto-merge would never complete. To close that gap, the auto-merge job posts an approving review *before* enabling auto-merge, gated by the same three trust-boundary guards above (semver-major bumps, the `openai/codex-action` exclude, and the `trust-boundary` label).
+The default-branch ruleset on `main` requires one approving code-owner review before merge. `GITHUB_TOKEN` cannot approve PRs and Dependabot cannot approve its own PRs, so without an additional approver auto-merge would never complete. To close that gap, the auto-merge job posts an approving review *before* enabling auto-merge, gated by the same set of guards above (semver-major bumps, the `openai/codex-action` exclude, and either security-review label).
 
 The approval is posted using a fine-grained PAT belonging to a code-owner, stored as the Dependabot secret **`DEPENDABOT_APPROVE_TOKEN`**. The PAT must be:
 
@@ -172,7 +197,7 @@ Configure under **Settings → Secrets and variables → Dependabot → New secr
 
 When the secret is unset, the approval step emits a warning and exits cleanly — auto-merge is still enabled, but the PR waits for a manual approving review.
 
-Auto-approval reviews carry the marker body `Auto-approved by the Dependabot Auto-Merge workflow (...)` so they are easy to identify in the PR review list. If a maintainer later applies the `trust-boundary` label, the reactive disable job revokes auto-merge but does not dismiss the bot review; the ruleset's `dismiss_stale_reviews_on_push: true` will clear it on the next push, and the maintainer can dismiss it manually before re-evaluating.
+Auto-approval reviews carry the marker body `Auto-approved by the Dependabot Auto-Merge workflow (...)` so they are easy to identify in the PR review list. If a maintainer later applies either security-review label, the reactive disable job revokes auto-merge but does not dismiss the bot review; the ruleset's `dismiss_stale_reviews_on_push: true` will clear it on the next push, and the maintainer can dismiss it manually before re-evaluating.
 
 ## Release process
 
@@ -196,15 +221,19 @@ Use this path when `prepare-release.yaml` is broken or an urgent hotfix needs cu
 
 1. Update `version` in `package.json`, then bump `package-lock.json` to the same version at both the top-level `version` and `packages[""].version`. Do not run `npm install --package-lock-only` or `npm version` for this — they re-resolve the dependency tree and would cause silent transitive bumps in a release-prep commit. A `jq`-based or hand edit of just those two lines is correct. The `tests.yaml` workflow rejects any PR where the two files disagree.
 2. Update `CHANGELOG.md` with the release date and any new entries.
-   - **2b. Trust-boundary callout.** If the release contains any PRs labeled `trust-boundary`, add a dedicated subsection to the CHANGELOG entry:
+   - **2b. Security-review callouts.** If the release contains any PRs labeled `trust-boundary` or `security-review-required`, add the matching dedicated subsection(s) to the CHANGELOG entry. A PR carrying both labels gets a bullet under both callouts:
 
      ```markdown
      ### ⚠️ Trust boundary change
 
-     - <what changed> — <why> — <what callers should re-review>
+     - <what data-flow / permission / contract changed> — <why> — <what callers should re-review>
+
+     ### 🔒 Containment-mechanism change
+
+     - <what containment mechanism changed> — <why> — <what callers should re-audit>
      ```
 
-     Applies to releases cut after this section lands; historical entries are not rewritten.
+     Applies to releases cut after each callout's section lands; historical entries are not rewritten. The `### 🔒 Containment-mechanism change` callout applies forward from the release in which this policy ships.
 3. Rebuild dist: `npm run build`.
    - **3b. Sync cross-doc SHA and version references.** When the canonical pin in `action.yaml`, `prepare/action.yaml`, `publish/action.yaml`, or `review/action.yaml` changes — or when any release bumps a third-party Action — update every other reference to that pin in the same release: `README.md` (including the "Adopting in enterprise environments" section), examples, and any other docs. The unified-pins rule (one SHA + tag per third-party Action across the entire repo) is enforced by CI on every PR and push to `main` by `.github/workflows/verify-action-pins.yaml`. The `ratchet-lint` job rejects any `uses:` that is not pinned to a full commit SHA, and the `verify-doc-pins` job (running `npm run verify:doc-pins`) fails when any tracked Markdown file references a third-party Action with a SHA or tag that drifts from the canonical pin in YAML. If either job fails, fix the listed files; do not bypass the check. The release-time sweep is now "verify CI passes" rather than a manual grep.
    - **3c. Complete the release gate (pre-merge items).** Before merging the release commit, walk [`docs/release-gate.md`](docs/release-gate.md) against the candidate commit: run the validation block, the dist-reproducibility check, and the manual security regression checks; resolve every pre-merge gate item to either `Verified by:` or `Waived:` with a tracked follow-up. The post-tag gate item (evidence-zip upload) is handled in step 7b after the GitHub Release is created and the self-pin refresh PR has merged.

--- a/docs/release-gate.md
+++ b/docs/release-gate.md
@@ -101,12 +101,28 @@ Every line in this gate ends in one of two states:
 
 Acceptance bars:
 
-- **Before tagging.** Every pre-merge gate item (Required validation, Dist reproducibility, Manual security regression checks, Conditional base-mode checks, Release-specific items, Trust-boundary cross-reference) is verified or waived; every waiver names its follow-up; the maintainer cutting the tag has signed off on the rollup.
+- **Before tagging.** Every pre-merge gate item (Required validation, Dist reproducibility, Manual security regression checks, Conditional base-mode checks, Release-specific items, Security-review-required cross-reference, Security-review sign-off) is verified or waived; every waiver names its follow-up; the maintainer cutting the tag has signed off on the rollup.
 - **After tagging.** The post-tag item ([Archiving the gate](#archiving-the-gate)) is verified once `release.yaml` has created the GitHub Release and the evidence zip has been uploaded. The release is not considered complete until this final item is signed off in the release PR thread or evidence record.
 
-## Trust-boundary cross-reference
+## Security-review-required cross-reference
 
-If the release contains any PR labeled `trust-boundary` that also contributes a release level (i.e. not `release: skip`), the CHANGELOG must include the dedicated `### ⚠️ Trust boundary change` callout per the [Release process / Trust-boundary changes](../CONTRIBUTING.md#trust-boundary-changes) rule in `CONTRIBUTING.md`. Skipped PRs do not appear in CHANGELOG entries, so a `trust-boundary` label on a `release: skip` PR (e.g. release-prep or internal infra) does not by itself trigger the callout requirement. The release PR's CHANGELOG diff is the source of truth — the gate does not re-list the trust-boundary policy here, only confirms it was applied.
+If the release contains any PR labeled `trust-boundary` or `security-review-required` that also contributes a release level (i.e. not `release: skip`), the CHANGELOG must include the matching dedicated callout(s) per the [Release process / Security-review-required changes](../CONTRIBUTING.md#security-review-required-changes) rule in `CONTRIBUTING.md`:
+
+- a PR labeled `trust-boundary` requires a `### ⚠️ Trust boundary change` subsection with a bullet for that PR;
+- a PR labeled `security-review-required` requires a `### 🔒 Containment-mechanism change` subsection with a bullet for that PR;
+- a PR carrying both labels appears as a bullet under both callouts.
+
+Skipped PRs do not appear in CHANGELOG entries, so either label on a `release: skip` PR (e.g. release-prep or internal infra) does not by itself trigger a callout requirement. The release PR's CHANGELOG diff is the source of truth — the gate does not re-list the policy here, only confirms it was applied.
+
+## Security-review sign-off
+
+Every PR in this release labeled `trust-boundary` or `security-review-required` is listed below with a Verified-by line confirming the security review actually happened. This is separate from normal PR approval — the reviewer walked the criteria list in [`CONTRIBUTING.md` → Security-review-required changes](../CONTRIBUTING.md#security-review-required-changes), classified the surface(s) touched, and judged the change.
+
+| # | PR | Class | Surfaces touched | State |
+|---|---|---|---|---|
+| 1 | _#PR_ | _`trust-boundary` / `security-review-required` / both_ | _e.g. data sent to OpenAI; secret scoping_ | _`Verified by: <maintainer> — <YYYY-MM-DD>` or `Waived: <rationale + tracked follow-up>`_ |
+
+If the release contains no PRs in either class, replace the example row with `_None — release contains no security-review-required changes._` and add a Verified-by line so the section is not left ambiguously empty.
 
 ## Archiving the gate
 

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -231,6 +231,29 @@ describe("extractSecurityReviewImpact", () => {
       extractSecurityReviewImpact("## Security-review impact\n<!-- placeholder -->\n"),
     ).toThrow(/empty after stripping HTML comments/);
   });
+
+  it("accepts the legacy `## Trust boundary impact` heading for PRs merged before the rename", () => {
+    const body = [
+      "## Summary",
+      "stuff",
+      "",
+      "## Trust boundary impact",
+      "<!-- helper -->",
+      "Adds new permission scope.",
+      "",
+      "## Test plan",
+      "- run tests",
+    ].join("\n");
+    expect(extractSecurityReviewImpact(body)).toBe(
+      "Adds new permission scope.",
+    );
+  });
+
+  it("rejects the legacy heading when its body is the template default 'None.'", () => {
+    expect(() =>
+      extractSecurityReviewImpact("## Trust boundary impact\nNone.\n"),
+    ).toThrow(/template default 'None\.'/);
+  });
 });
 
 describe("renderChangelogEntry", () => {

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -15,7 +15,7 @@ import {
   consolidateRcSections,
   existingBodyHasMaintainerEdits,
   existingBodyHasMaintainerSignoff,
-  extractTrustBoundaryImpact,
+  extractSecurityReviewImpact,
   findSignoffSectionStart,
   formatPullRequestEntry,
   parseGitRemoteUrl,
@@ -141,6 +141,38 @@ describe("categorizePullRequest", () => {
     expect(sections).toContain("Added");
     expect(sections).toContain("⚠️ Trust boundary change");
   });
+
+  it("adds the containment-mechanism section additively for security-review-required", () => {
+    const sections = categorizePullRequest(
+      makePr({
+        number: 1,
+        labels: [
+          { name: "release: minor" },
+          { name: "enhancement" },
+          { name: "security-review-required" },
+        ],
+      }),
+    );
+    expect(sections).toContain("Added");
+    expect(sections).toContain("🔒 Containment-mechanism change");
+    expect(sections).not.toContain("⚠️ Trust boundary change");
+  });
+
+  it("adds both security-review sections when a PR carries both labels", () => {
+    const sections = categorizePullRequest(
+      makePr({
+        number: 1,
+        labels: [
+          { name: "release: minor" },
+          { name: "enhancement" },
+          { name: "trust-boundary" },
+          { name: "security-review-required" },
+        ],
+      }),
+    );
+    expect(sections).toContain("⚠️ Trust boundary change");
+    expect(sections).toContain("🔒 Containment-mechanism change");
+  });
 });
 
 describe("formatPullRequestEntry", () => {
@@ -153,50 +185,50 @@ describe("formatPullRequestEntry", () => {
   });
 });
 
-describe("extractTrustBoundaryImpact", () => {
+describe("extractSecurityReviewImpact", () => {
   it("extracts a paragraph and strips comments", () => {
     const body = [
       "## Summary",
       "stuff",
       "",
-      "## Trust boundary impact",
+      "## Security-review impact",
       "<!-- helper -->",
       "Adds outbound HTTP to api.example.com.",
       "",
       "## Test plan",
       "- run tests",
     ].join("\n");
-    expect(extractTrustBoundaryImpact(body)).toBe(
+    expect(extractSecurityReviewImpact(body)).toBe(
       "Adds outbound HTTP to api.example.com.",
     );
   });
 
   it("collapses multi-line paragraphs to a single line", () => {
     const body = [
-      "## Trust boundary impact",
+      "## Security-review impact",
       "Adds outbound HTTP",
       "to api.example.com.",
     ].join("\n");
-    expect(extractTrustBoundaryImpact(body)).toBe(
+    expect(extractSecurityReviewImpact(body)).toBe(
       "Adds outbound HTTP to api.example.com.",
     );
   });
 
   it("throws when the heading is missing", () => {
-    expect(() => extractTrustBoundaryImpact("## Summary\nfoo")).toThrow(
-      /Missing '## Trust boundary impact' heading/,
+    expect(() => extractSecurityReviewImpact("## Summary\nfoo")).toThrow(
+      /Missing '## Security-review impact' heading/,
     );
   });
 
   it("throws when the body is the template default 'None.'", () => {
     expect(() =>
-      extractTrustBoundaryImpact("## Trust boundary impact\nNone.\n"),
+      extractSecurityReviewImpact("## Security-review impact\nNone.\n"),
     ).toThrow(/template default 'None\.'/);
   });
 
   it("throws when only HTML comments remain", () => {
     expect(() =>
-      extractTrustBoundaryImpact("## Trust boundary impact\n<!-- placeholder -->\n"),
+      extractSecurityReviewImpact("## Security-review impact\n<!-- placeholder -->\n"),
     ).toThrow(/empty after stripping HTML comments/);
   });
 });
@@ -255,12 +287,55 @@ describe("renderChangelogEntry", () => {
           { name: "enhancement" },
           { name: "trust-boundary" },
         ],
-        body: "## Trust boundary impact\nAdds new permission scope.",
+        body: "## Security-review impact\nAdds new permission scope.",
       }),
     ];
     const result = renderChangelogEntry(prs, "2.1.0", "2026-05-01");
     expect(result).toContain("### ⚠️ Trust boundary change");
     expect(result).toContain("Adds new permission scope");
+  });
+
+  it("renders containment-mechanism callout for security-review-required PRs", () => {
+    const prs = [
+      makePr({
+        number: 11,
+        title: "Tighten sandbox",
+        labels: [
+          { name: "release: patch" },
+          { name: "security" },
+          { name: "security-review-required" },
+        ],
+        body: "## Security-review impact\nFlips openai/codex-action sandbox to read-only.",
+      }),
+    ];
+    const result = renderChangelogEntry(prs, "2.1.0", "2026-05-01");
+    expect(result).toContain("### 🔒 Containment-mechanism change");
+    expect(result).toContain("Flips openai/codex-action sandbox to read-only");
+    expect(result).not.toContain("### ⚠️ Trust boundary change");
+  });
+
+  it("renders both callouts when a PR carries both security-review labels", () => {
+    const prs = [
+      makePr({
+        number: 12,
+        title: "Boundary + containment",
+        labels: [
+          { name: "release: minor" },
+          { name: "enhancement" },
+          { name: "trust-boundary" },
+          { name: "security-review-required" },
+        ],
+        body: "## Security-review impact\nAdds outbound destination AND tightens sandbox.",
+      }),
+    ];
+    const result = renderChangelogEntry(prs, "2.1.0", "2026-05-01");
+    const trustIdx = result.indexOf("### ⚠️ Trust boundary change");
+    const containIdx = result.indexOf("### 🔒 Containment-mechanism change");
+    expect(trustIdx).toBeGreaterThan(0);
+    expect(containIdx).toBeGreaterThan(trustIdx);
+    expect(
+      result.match(/Adds outbound destination AND tightens sandbox/g),
+    ).toHaveLength(2);
   });
 
   it("emits a placeholder when nothing notable changed", () => {
@@ -611,7 +686,8 @@ describe("gate doc / PR body checklist drift", () => {
     "codex-prepare", // Prompt-artifact leakage check (artifact name shared by both)
     "review-reference-source: base", // Conditional base-mode checks
     "Release-specific items",
-    "Trust-boundary",
+    "Security-review-required cross-reference",
+    "Security-review sign-off",
     "Archiving the gate",
   ] as const;
 
@@ -685,19 +761,27 @@ describe("buildPrBody", () => {
     expect(body).toContain("widen `allow-users`");
     expect(body).toContain("- [ ] Conditional `review-reference-source: base` checks");
     expect(body).toContain("- [ ] Release-specific items table is filled below this checklist");
-    expect(body).toContain("- [ ] Trust-boundary CHANGELOG callout");
-    expect(body).toContain("contributing a release level (i.e. not `release: skip`)");
+    expect(body).toContain("- [ ] Security-review CHANGELOG callouts");
+    expect(body).toContain("`### ⚠️ Trust boundary change`");
+    expect(body).toContain("`### 🔒 Containment-mechanism change`");
+    expect(body).toContain("- [ ] Security-review sign-off table is filled below this checklist");
+    expect(body).toContain("contributing a release level");
+    expect(body).toContain("Skipped PRs do not appear in CHANGELOG entries");
     expect(body).toContain("- [ ] Gate evidence zip attached to the GitHub Release");
     expect(body).toContain("### Release-specific items");
     expect(body).toContain("| # | Item | Owning work | State |");
+    expect(body).toContain("### Security-review sign-off");
+    expect(body).toContain("| # | PR | Class | Surfaces touched | State |");
 
     const preMergeIndex = body.indexOf("**Pre-merge:**");
     const postTagIndex = body.indexOf("**Post-tag:**");
     const evidenceZipIndex = body.indexOf("Gate evidence zip");
-    const tableIndex = body.indexOf("| # | Item | Owning work | State |");
+    const releaseSpecificTableIndex = body.indexOf("| # | Item | Owning work | State |");
+    const securityReviewTableIndex = body.indexOf("| # | PR | Class | Surfaces touched | State |");
     expect(postTagIndex).toBeGreaterThan(preMergeIndex);
     expect(evidenceZipIndex).toBeGreaterThan(postTagIndex);
-    expect(tableIndex).toBeGreaterThan(evidenceZipIndex);
+    expect(releaseSpecificTableIndex).toBeGreaterThan(evidenceZipIndex);
+    expect(securityReviewTableIndex).toBeGreaterThan(releaseSpecificTableIndex);
   });
 });
 
@@ -900,6 +984,8 @@ describe("buildSignoffSection (with explicit gateDocUrl)", () => {
     expect(section).toContain(`(${url})`);
     expect(section).toContain(`(${url}#required-validation)`);
     expect(section).toContain(`(${url}#release-specific-items)`);
+    expect(section).toContain(`(${url}#security-review-required-cross-reference)`);
+    expect(section).toContain(`(${url}#security-review-sign-off)`);
     expect(section).toContain(`(${url}#archiving-the-gate)`);
     expect(section).not.toContain("milanhorvatovic/codex-ai-code-review-action");
   });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -138,10 +138,22 @@ export function formatPullRequestEntry(pr: PullRequest): string {
 }
 
 export function extractSecurityReviewImpact(prBody: string): string {
-  const headingMatch = /^## Security-review impact\s*$/m.exec(prBody);
+  // Match either the current `## Security-review impact` heading or the legacy
+  // `## Trust boundary impact` heading. The PR template heading was renamed by
+  // #117 along with the extractor; trust-boundary PRs merged from the legacy
+  // template before that rename had a valid `## Trust boundary impact` section
+  // at merge time. This fallback lets those PRs flow through CHANGELOG
+  // generation between the last release and the first release that follows
+  // #117 — without it, a trust-boundary-labeled PR merged before the heading
+  // rename would throw here when included in a release window. Once a release
+  // ships and the legacy-bodied PRs are behind us, the `Trust boundary impact`
+  // alternative can be dropped (tracked as a future cleanup; the cost of
+  // keeping it is one regex alternation).
+  const headingMatch =
+    /^## (?:Security-review impact|Trust boundary impact)\s*$/m.exec(prBody);
   if (!headingMatch) {
     throw new Error(
-      "Missing '## Security-review impact' heading. Security-review-required PRs must include the section from .github/PULL_REQUEST_TEMPLATE.md.",
+      "Missing '## Security-review impact' heading (legacy '## Trust boundary impact' also accepted for PRs merged before the rename). Security-review-required PRs must include the section from .github/PULL_REQUEST_TEMPLATE.md.",
     );
   }
   const after = prBody.slice(headingMatch.index + headingMatch[0].length);

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -51,10 +51,13 @@ export const SECTION_ORDER = [
   "Documentation",
   "Process",
   "⚠️ Trust boundary change",
+  "🔒 Containment-mechanism change",
 ] as const;
 
 const TRUST_BOUNDARY_SECTION = "⚠️ Trust boundary change";
 const TRUST_BOUNDARY_LABEL = "trust-boundary";
+const CONTAINMENT_MECHANISM_SECTION = "🔒 Containment-mechanism change";
+const SECURITY_REVIEW_LABEL = "security-review-required";
 
 export function parseTargetVersion(input: string): string {
   return parseVersion(input);
@@ -124,6 +127,9 @@ export function categorizePullRequest(pr: PullRequest): readonly string[] {
   if (pr.labels.some((l) => l.name === TRUST_BOUNDARY_LABEL)) {
     sections.add(TRUST_BOUNDARY_SECTION);
   }
+  if (pr.labels.some((l) => l.name === SECURITY_REVIEW_LABEL)) {
+    sections.add(CONTAINMENT_MECHANISM_SECTION);
+  }
   return [...sections];
 }
 
@@ -131,11 +137,11 @@ export function formatPullRequestEntry(pr: PullRequest): string {
   return `- ${pr.title} ([#${pr.number}](${pr.url}))`;
 }
 
-export function extractTrustBoundaryImpact(prBody: string): string {
-  const headingMatch = /^## Trust boundary impact\s*$/m.exec(prBody);
+export function extractSecurityReviewImpact(prBody: string): string {
+  const headingMatch = /^## Security-review impact\s*$/m.exec(prBody);
   if (!headingMatch) {
     throw new Error(
-      "Missing '## Trust boundary impact' heading. Trust-boundary PRs must include the section from .github/PULL_REQUEST_TEMPLATE.md.",
+      "Missing '## Security-review impact' heading. Security-review-required PRs must include the section from .github/PULL_REQUEST_TEMPLATE.md.",
     );
   }
   const after = prBody.slice(headingMatch.index + headingMatch[0].length);
@@ -148,7 +154,7 @@ export function extractTrustBoundaryImpact(prBody: string): string {
   }
   if (withoutComments.includes("<!--")) {
     throw new Error(
-      "'## Trust boundary impact' section contains an unclosed HTML comment; fix the PR body.",
+      "'## Security-review impact' section contains an unclosed HTML comment; fix the PR body.",
     );
   }
   const stripped = withoutComments
@@ -159,12 +165,12 @@ export function extractTrustBoundaryImpact(prBody: string): string {
     .trim();
   if (stripped === "") {
     throw new Error(
-      "'## Trust boundary impact' section is empty after stripping HTML comments.",
+      "'## Security-review impact' section is empty after stripping HTML comments.",
     );
   }
   if (stripped === "None." || stripped === "None") {
     throw new Error(
-      "'## Trust boundary impact' section still contains the template default 'None.' for a trust-boundary-labeled PR.",
+      "'## Security-review impact' section still contains the template default 'None.' for a PR labeled trust-boundary or security-review-required.",
     );
   }
   return stripped;
@@ -173,19 +179,30 @@ export function extractTrustBoundaryImpact(prBody: string): string {
 type SectionEntries = {
   standard: Map<string, Map<number, string>>;
   trustBoundary: Map<number, string>;
+  containmentMechanism: Map<number, string>;
 };
 
 function collectEntries(prs: PullRequest[]): SectionEntries {
   const standard = new Map<string, Map<number, string>>();
   const trustBoundary = new Map<number, string>();
+  const containmentMechanism = new Map<number, string>();
   for (const pr of prs) {
     if (releaseLevelOf(pr) === "skip") continue;
     const sections = categorizePullRequest(pr);
     const entry = formatPullRequestEntry(pr);
+    // Both security-review labels share a single `## Security-review impact`
+    // section in the PR body. Extract it once when either callout applies; the
+    // same impact text is bulleted under each matching callout heading, so a
+    // PR labeled with both classes appears under both with consistent prose.
+    const needsImpact =
+      sections.includes(TRUST_BOUNDARY_SECTION) ||
+      sections.includes(CONTAINMENT_MECHANISM_SECTION);
+    const impact = needsImpact ? extractSecurityReviewImpact(pr.body) : "";
     for (const section of sections) {
       if (section === TRUST_BOUNDARY_SECTION) {
-        const impact = extractTrustBoundaryImpact(pr.body);
         trustBoundary.set(pr.number, `${entry} — ${impact}`);
+      } else if (section === CONTAINMENT_MECHANISM_SECTION) {
+        containmentMechanism.set(pr.number, `${entry} — ${impact}`);
       } else {
         let bucket = standard.get(section);
         if (bucket === undefined) {
@@ -196,7 +213,7 @@ function collectEntries(prs: PullRequest[]): SectionEntries {
       }
     }
   }
-  return { standard, trustBoundary };
+  return { standard, trustBoundary, containmentMechanism };
 }
 
 export function renderChangelogEntry(
@@ -204,11 +221,12 @@ export function renderChangelogEntry(
   version: string,
   today: string,
 ): string {
-  const { standard, trustBoundary } = collectEntries(prs);
+  const { standard, trustBoundary, containmentMechanism } = collectEntries(prs);
   const lines: string[] = [`## [${version}] - ${today}`, ""];
   let appended = false;
   for (const section of SECTION_ORDER) {
     if (section === TRUST_BOUNDARY_SECTION) continue;
+    if (section === CONTAINMENT_MECHANISM_SECTION) continue;
     const bucket = standard.get(section);
     if (bucket === undefined || bucket.size === 0) continue;
     const sorted = [...bucket.values()].sort((a, b) => a.localeCompare(b));
@@ -220,6 +238,15 @@ export function renderChangelogEntry(
   if (trustBoundary.size > 0) {
     const sorted = [...trustBoundary.values()].sort((a, b) => a.localeCompare(b));
     lines.push(`### ${TRUST_BOUNDARY_SECTION}`, "");
+    for (const entry of sorted) lines.push(entry);
+    lines.push("");
+    appended = true;
+  }
+  if (containmentMechanism.size > 0) {
+    const sorted = [...containmentMechanism.values()].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    lines.push(`### ${CONTAINMENT_MECHANISM_SECTION}`, "");
     for (const entry of sorted) lines.push(entry);
     lines.push("");
     appended = true;
@@ -589,7 +616,7 @@ export function parseGitRemoteUrl(
 // boxes) still fires regardless, so real sign-off on an older template is
 // still preserved.
 export const SIGNOFF_TEMPLATE_VERSION_MARKER =
-  "<!-- release-gate-template-version:v1 -->";
+  "<!-- release-gate-template-version:v2 -->";
 
 export function buildSignoffSection(gateDocUrl: string = resolveGateDocUrl()): string {
   const lines: string[] = [
@@ -606,7 +633,8 @@ export function buildSignoffSection(gateDocUrl: string = resolveGateDocUrl()): s
     "- [ ] Prompt-artifact leakage check: the resolved `reviewReference` flowing into the assembled prompt comes only from the validated path-resolver, never raw runner-local content. Confirmed by `src/prepare/referenceFile.test.ts` (path validation) and `src/prepare/main.test.ts` ('uses the resolved custom reference content for each prompt'). Direct artifact inspection requires the dogfood workflow's `allow-users` (in `.github/workflows/codex-review.yaml`) to include the inspecting maintainer's account; release-bot PRs and scratch PRs from other accounts are skipped. The allow-listed maintainer can open a scratch PR against the merge candidate and run `gh run download <run-id> --name codex-prepare` within the prepare job's retention window. Other maintainers either widen `allow-users` on a scratch branch first or rely on the unit-test coverage above.",
     "- [ ] Conditional `review-reference-source: base` checks are run, or waived with a rationale.",
     `- [ ] Release-specific items table is filled below this checklist with cross-references to owning PRs/issues, and each row resolved to \`Verified by:\` or \`Waived:\` (see [Release-specific items](${gateDocUrl}#release-specific-items)).`,
-    "- [ ] Trust-boundary CHANGELOG callout is present if any merged PR contributing a release level (i.e. not `release: skip`) is labeled `trust-boundary`. (Skipped PRs do not appear in CHANGELOG entries, so they cannot trigger the callout requirement.)",
+    `- [ ] Security-review CHANGELOG callouts are present per the [Security-review-required cross-reference](${gateDocUrl}#security-review-required-cross-reference) rule: \`### ⚠️ Trust boundary change\` for every merged \`trust-boundary\`-labeled PR contributing a release level, \`### 🔒 Containment-mechanism change\` for every merged \`security-review-required\`-labeled PR contributing a release level, both when a PR carries both labels. (Skipped PRs do not appear in CHANGELOG entries, so they cannot trigger the callout requirement.)`,
+    `- [ ] Security-review sign-off table is filled below this checklist with one row per merged PR labeled \`trust-boundary\` or \`security-review-required\` (or \`_None — release contains no security-review-required changes._\` if applicable), each row resolved to \`Verified by:\` or \`Waived:\` (see [Security-review sign-off](${gateDocUrl}#security-review-sign-off)).`,
     "",
     "**Post-tag:**",
     "",
@@ -619,6 +647,14 @@ export function buildSignoffSection(gateDocUrl: string = resolveGateDocUrl()): s
     "| # | Item | Owning work | State |",
     "|---|---|---|---|",
     "| 1 | _short description_ | _PR # / issue # / workflow file_ | _`Verified by: <maintainer> — <YYYY-MM-DD>` or `Waived: <rationale + tracked follow-up>`_ |",
+    "",
+    "### Security-review sign-off",
+    "",
+    `Populate the table below per [docs/release-gate.md → Security-review sign-off](${gateDocUrl}#security-review-sign-off). Add one row per merged PR labeled \`trust-boundary\` or \`security-review-required\`; resolve each State to \`Verified by:\` or \`Waived:\` per the sign-off convention. If the release contains no PRs in either class, replace the example row with \`_None — release contains no security-review-required changes._\` and add a Verified-by line.`,
+    "",
+    "| # | PR | Class | Surfaces touched | State |",
+    "|---|---|---|---|---|",
+    "| 1 | _#PR_ | _`trust-boundary` / `security-review-required` / both_ | _e.g. data sent to OpenAI; secret scoping_ | _`Verified by: <maintainer> — <YYYY-MM-DD>` or `Waived: <rationale + tracked follow-up>`_ |",
   ];
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary

- Extends the existing #45 trust-boundary policy with a sibling class of *security-review-required* changes — containment-mechanism surfaces (event triggers, secret scoping, model-execution sandboxing, `review-reference-*` behavior, `prepare`/`review`/`publish` job-boundary moves) — under one umbrella `## Security-review-required changes` heading in `CONTRIBUTING.md`. Both classes share the same Dependabot enforcement and release-gate sign-off discipline.
- Adds a peer label `security-review-required` and a peer CHANGELOG callout `### 🔒 Containment-mechanism change`. The existing `trust-boundary` label and `### ⚠️ Trust boundary change` callout are unchanged. PR template, `.github/SECURITY.md`, `docs/release-gate.md`, and `scripts/prepare-release.ts` are updated to emit both classes wherever they previously emitted one.
- Adds a per-PR `## Security-review sign-off` table in `docs/release-gate.md` (and in the auto-generated release PR body) so each labeled PR carries an explicit Verified-by line — separate from normal PR approval.
- Closes #96.

## Security-review impact

This PR carries both `trust-boundary` and `security-review-required` labels because it modifies maintainer-side review obligations around future changes in both classes — the same precedent as #45 / #69, which tagged the original policy PR `trust-boundary` despite not changing any code-level boundary.

It does not change any data destinations, telemetry, permissions, artifact contents, sandboxing, secret scoping, event triggers, reference-file validation, or job boundaries at the code level — those surfaces are unchanged. The label and callout obligations apply because adopters who have already audited their fork should re-read this policy extension before pulling a new SHA.

The dependabot-auto-merge.yaml widening is the one mechanical behavior change: every existing `trust-boundary` guard layer (concurrency cancel, two `if:` clauses, runtime tri-state helper, reactive disable job) now also recognizes the new `security-review-required` label. The `openai/codex-action` exclude-by-name guard is preserved; no new dependency-name guard is added, and an inline comment documents that the exclude is intentionally action-level deps only.

## Release label

`release: patch` — documentation enhancement plus auditor-facing policy extension in `SECURITY.md`. The dependabot-auto-merge.yaml and `prepare-release.ts` edits are subordinate to the doc change.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test` — 505/505 pass; new tests cover the `security-review-required` label classification, dual-callout rendering (trust-boundary only, containment-mechanism only, both at once), the renamed `extractSecurityReviewImpact` extractor, and the gate-doc sign-off table assertions
- [x] `npm run build` — no `dist/` drift (script-only changes)
- [x] `npm run verify:doc-pins`
- [x] `npm run verify:prose-style`
- [x] `actionlint .github/workflows/dependabot-auto-merge.yaml`