### PR TITLE
chore: unify Dependabot group structure

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,12 @@ updates:
           - "milanhorvatovic/codex-ai-code-review-action"
         patterns:
           - "*"
+        # Keep majors out of the group so they arrive as standalone PRs the auto-
+        # merge workflow's semver-major exclusion can route to manual review
+        # without dragging unrelated patch/minor bumps along.
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "github-actions"
@@ -28,10 +34,17 @@ updates:
     directory: "/"
     package-ecosystem: "npm"
     groups:
-      dev-dependencies:
-        dependency-type: "development"
-      production-dependencies:
-        dependency-type: "production"
+      # Single group per ecosystem mirrors the github-actions shape above. The
+      # prior dev/prod split never branched anywhere downstream — `rebuild-dist`
+      # runs for every Dependabot PR regardless of dependency type, and the
+      # auto-merge / release-label / reconciler workflows operate on PR-level
+      # state, not group identity.
+      npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"
       - "npm"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,6 +23,11 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+      # `release: patch` is the fast-path default for grouped patch/minor
+      # bumps; for standalone semver-major PRs (which split out of the group
+      # because of `update-types: [minor, patch]` above), the
+      # `dependabot-release-label.yaml` workflow replaces it with
+      # `release: major` based on the effective update-type.
       - "release: patch"
     schedule:
       day: "monday"
@@ -48,6 +53,11 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+      # `release: patch` is the fast-path default for grouped patch/minor
+      # bumps; for standalone semver-major PRs (which split out of the group
+      # because of `update-types: [minor, patch]` above), the
+      # `dependabot-release-label.yaml` workflow replaces it with
+      # `release: major` based on the effective update-type.
       - "release: patch"
     schedule:
       day: "monday"

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -18,9 +18,12 @@ name: Dependabot Release Label
 #      PRs. A standalone semver-major PR inherits `release: patch` from
 #      the static config, which would mis-classify it for the release-prep
 #      automation. This workflow recomputes the effective update-type and
-#      REPLACES the static `release: patch` with `release: major` when the
-#      two disagree. (Patch and minor bumps stay through the fast path:
-#      the static label is already correct.)
+#      REPLACES the static `release: patch` with `release: major` for that
+#      standalone case only — grouped patch/minor PRs keep the static
+#      `release: patch` even when the group's effective update-type rolls
+#      up to `version-update:semver-minor`, because the static label
+#      encodes the project's policy that grouped patch/minor bumps release
+#      as patch.
 #
 # Effective-update-type derivation mirrors `dependabot-auto-merge.yaml` so
 # SHA→SHA same-version dogfood self-reference bumps (which `fetch-metadata`
@@ -119,21 +122,34 @@ jobs:
           current_json="$(list_release_labels)"
           current_count=$(jq 'length' <<<"$current_json")
 
-          # Four cases to handle:
-          #   - 0 release labels  → add the desired one (security-update
-          #     backstop case: Dependabot didn't apply the static label).
-          #   - 1 label matching  → no-op (fast path: the static label from
-          #     dependabot.yaml is already correct, which is the common case
-          #     for grouped patch/minor bumps).
-          #   - 1 label mismatch  → replace it with the desired one
-          #     (standalone-semver-major correction case: the static
-          #     `release: patch` from dependabot.yaml doesn't match the
-          #     effective update-type, typically because a semver-major
-          #     bump split out of its group as a standalone PR).
-          #   - >1 labels         → maintainer applied an additional release
-          #     label manually; leave the conflict for `verify-pr-release-label`
-          #     to flag and the maintainer to triage. The workflow shouldn't
-          #     second-guess a manual override.
+          # Decision tree:
+          #   - 0 release labels → add `desired` (security-update backstop
+          #     case: Dependabot didn't inherit the static label list from
+          #     `.github/dependabot.yaml`).
+          #   - 1 label matching `desired` → no-op (fast path: the static
+          #     label is already correct).
+          #   - 1 label not matching `desired`:
+          #       - If `desired == "release: major"` → replace. This is the
+          #         standalone-semver-major correction case: dependabot.yaml
+          #         applies `release: patch` to every PR from the configured
+          #         groups, but a semver-major bump splits out of its group
+          #         as a standalone PR (because of the group's
+          #         `update-types: [minor, patch]` filter) and inherits the
+          #         wrong static label.
+          #       - Otherwise → keep the current label. dependabot.yaml's
+          #         static `release: patch` encodes the user's intent that
+          #         grouped patch/minor bumps release as patch, even when
+          #         the group's effective update-type rolls up to
+          #         `version-update:semver-minor` (a group containing any
+          #         minor bump alongside patches). The workflow MUST NOT
+          #         relabel grouped minor PRs to `release: minor` — that
+          #         would contradict the dependabot.yaml comments and turn
+          #         routine minor dependency bumps into minor releases of
+          #         this Action. Maintainer-applied overrides like
+          #         `release: skip` are preserved here for the same reason.
+          #   - >1 labels → leave for `verify-pr-release-label` to flag and
+          #     the maintainer to triage. The workflow shouldn't second-
+          #     guess a manual override.
           if [ "$current_count" = "0" ]; then
             echo "No release label present; adding '$desired'."
             gh pr edit "$PR_URL" --add-label "$desired"
@@ -143,7 +159,11 @@ jobs:
               echo "Release label '$desired' already correct; nothing to do."
               exit 0
             fi
-            echo "Replacing '$current' with '$desired' (effective update-type: $UPDATE_TYPE)."
+            if [ "$desired" != "release: major" ]; then
+              echo "Keeping '$current' (effective update-type: $UPDATE_TYPE). The static label encodes the grouped patch/minor intent from dependabot.yaml; only standalone semver-major PRs get auto-corrected."
+              exit 0
+            fi
+            echo "Replacing '$current' with '$desired' (standalone semver-major correction; effective update-type: $UPDATE_TYPE)."
             gh pr edit "$PR_URL" --add-label "$desired" --remove-label "$current"
           else
             echo "::warning::PR has multiple release labels ($(jq -c '.' <<<"$current_json")); leaving as-is for manual triage."

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -18,12 +18,16 @@ name: Dependabot Release Label
 #      PRs. A standalone semver-major PR inherits `release: patch` from
 #      the static config, which would mis-classify it for the release-prep
 #      automation. This workflow recomputes the effective update-type and
-#      REPLACES the static `release: patch` with `release: major` for that
-#      standalone case only — grouped patch/minor PRs keep the static
-#      `release: patch` even when the group's effective update-type rolls
-#      up to `version-update:semver-minor`, because the static label
-#      encodes the project's policy that grouped patch/minor bumps release
-#      as patch.
+#      REPLACES `release: patch` with `release: major` only for that
+#      specific static-default mismatch (`current == "release: patch"` +
+#      effective type semver-major). Grouped patch/minor PRs keep the
+#      static `release: patch` even when the group's effective update-type
+#      rolls up to `version-update:semver-minor`, because the static
+#      label encodes the project's policy that grouped patch/minor bumps
+#      release as patch. Maintainer-applied overrides (`release: skip`,
+#      `release: minor`, etc.) are preserved on the same principle: the
+#      auto-correction is limited to the known static-default mismatch
+#      so a reopened PR with a deliberate maintainer label survives.
 #
 # Effective-update-type derivation mirrors `dependabot-auto-merge.yaml` so
 # SHA→SHA same-version dogfood self-reference bumps (which `fetch-metadata`
@@ -129,27 +133,44 @@ jobs:
           #   - 1 label matching `desired` → no-op (fast path: the static
           #     label is already correct).
           #   - 1 label not matching `desired`:
-          #       - If `desired == "release: major"` → replace. This is the
-          #         standalone-semver-major correction case: dependabot.yaml
-          #         applies `release: patch` to every PR from the configured
-          #         groups, but a semver-major bump splits out of its group
-          #         as a standalone PR (because of the group's
-          #         `update-types: [minor, patch]` filter) and inherits the
-          #         wrong static label.
-          #       - Otherwise → keep the current label. dependabot.yaml's
-          #         static `release: patch` encodes the user's intent that
-          #         grouped patch/minor bumps release as patch, even when
-          #         the group's effective update-type rolls up to
-          #         `version-update:semver-minor` (a group containing any
-          #         minor bump alongside patches). The workflow MUST NOT
-          #         relabel grouped minor PRs to `release: minor` — that
-          #         would contradict the dependabot.yaml comments and turn
-          #         routine minor dependency bumps into minor releases of
-          #         this Action. Maintainer-applied overrides like
-          #         `release: skip` are preserved here for the same reason.
-          #   - >1 labels → leave for `verify-pr-release-label` to flag and
-          #     the maintainer to triage. The workflow shouldn't second-
-          #     guess a manual override.
+          #       - If `desired == "release: major"` AND
+          #         `current == "release: patch"` → replace. This is the
+          #         standalone-semver-major correction case, narrowly
+          #         scoped to the known static-default mismatch:
+          #         dependabot.yaml applies `release: patch` to every PR
+          #         from the configured groups, but a semver-major bump
+          #         splits out of its group as a standalone PR (because of
+          #         the group's `update-types: [minor, patch]` filter) and
+          #         inherits the wrong static label.
+          #       - Otherwise → keep the current label. Two distinct
+          #         reasons converge on the same behavior:
+          #           (a) Grouped patch/minor case (`desired` is
+          #               `release: minor` or `release: patch`,
+          #               `current` is `release: patch`):
+          #               dependabot.yaml's static `release: patch`
+          #               encodes the project's intent that grouped
+          #               patch/minor bumps release as patch, even when
+          #               the group's effective update-type rolls up to
+          #               `version-update:semver-minor` (a group
+          #               containing any minor bump alongside patches).
+          #               The workflow MUST NOT relabel grouped minor PRs
+          #               to `release: minor` — that would turn routine
+          #               grouped minor dependency bumps into minor
+          #               releases of this Action.
+          #           (b) Maintainer-override case (`current` is
+          #               `release: skip`, `release: minor`, etc., applied
+          #               manually before the workflow ran — most
+          #               commonly on a reopened PR where the maintainer
+          #               had intentionally changed the label).
+          #               Replacing it would steamroll the manual intent
+          #               and could (mis)include the PR in a major
+          #               release. The auto-correction is limited to the
+          #               KNOWN static-default mismatch; anything else is
+          #               left for `verify-pr-release-label` to flag if
+          #               the label disagrees with policy.
+          #   - >1 labels → leave for `verify-pr-release-label` to flag
+          #     and the maintainer to triage. The workflow shouldn't
+          #     second-guess a manual override.
           if [ "$current_count" = "0" ]; then
             echo "No release label present; adding '$desired'."
             gh pr edit "$PR_URL" --add-label "$desired"
@@ -159,8 +180,8 @@ jobs:
               echo "Release label '$desired' already correct; nothing to do."
               exit 0
             fi
-            if [ "$desired" != "release: major" ]; then
-              echo "Keeping '$current' (effective update-type: $UPDATE_TYPE). The static label encodes the grouped patch/minor intent from dependabot.yaml; only standalone semver-major PRs get auto-corrected."
+            if [ "$desired" != "release: major" ] || [ "$current" != "release: patch" ]; then
+              echo "Keeping '$current' (effective update-type: $UPDATE_TYPE). Auto-correction only fires for the known static-default mismatch (current 'release: patch' + standalone semver-major effective type); anything else is treated as grouped-intent or a manual override."
               exit 0
             fi
             echo "Replacing '$current' with '$desired' (standalone semver-major correction; effective update-type: $UPDATE_TYPE)."

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -166,8 +166,13 @@ jobs:
           #               and could (mis)include the PR in a major
           #               release. The auto-correction is limited to the
           #               KNOWN static-default mismatch; anything else is
-          #               left for `verify-pr-release-label` to flag if
-          #               the label disagrees with policy.
+          #               preserved as grouped intent or a maintainer
+          #               override. (No other workflow cross-checks the
+          #               label against Dependabot's effective update-
+          #               type — `verify-pr-release-label` only enforces
+          #               "exactly one canonical `release: *` label",
+          #               which a canonical-but-policy-disagreeing label
+          #               still satisfies.)
           #   - >1 labels → leave for `verify-pr-release-label` to flag
           #     and the maintainer to triage. The workflow shouldn't
           #     second-guess a manual override.

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -1,22 +1,39 @@
 name: Dependabot Release Label
 
-# Backstop that adds the `release: <level>` label to Dependabot PRs that did
-# not inherit one from `.github/dependabot.yaml`. Configured-group PRs (npm,
-# github-actions) pick up `release: patch` from the labels list there, but
-# Dependabot security-update PRs (the built-in `npm_and_yarn` group, not a
-# group we configure) inconsistently apply those labels — so the required
-# `verify-pr-release-label` check fails and auto-merge cannot complete.
+# Reconciles the `release: <level>` label on every Dependabot PR to match the
+# effective update-type derived from Dependabot's metadata. Two distinct
+# scenarios this addresses:
 #
-# Mirrors the effective-update-type derivation from `dependabot-auto-merge.yaml`
-# so SHA→SHA same-version dogfood self-reference bumps (which `fetch-metadata`
-# conservatively reports as semver-major) classify as patch here too — keeping
-# the label in lockstep with the merge policy. A pre-add label query plus a
-# post-add recheck bracket `gh pr edit`: the pre-add query skips when a label
-# is already present, the post-add recheck rolls back the workflow-applied
-# label if a maintainer's manual `release: *` raced into the check-then-act
-# window, leaving the manual override intact and a single release label on the
-# PR. (A maintainer applying the *same* label we'd compute is a set-semantics
-# no-op — the PR ends up with one label and no rollback fires.)
+#   1. Backstop for absent labels. Dependabot security-update PRs (the
+#      built-in `npm_and_yarn` group, not a group configured in our
+#      `.github/dependabot.yaml`) inconsistently apply the static label
+#      list, so the required `verify-pr-release-label` check would
+#      otherwise fail and auto-merge cannot complete.
+#
+#   2. Corrector for the standalone-semver-major case. Our
+#      `.github/dependabot.yaml` applies `release: patch` statically to
+#      every PR from the npm and github-actions ecosystems, but since
+#      those groups now carry `update-types: [minor, patch]`, semver-major
+#      bumps split out of the group and arrive as standalone Dependabot
+#      PRs. A standalone semver-major PR inherits `release: patch` from
+#      the static config, which would mis-classify it for the release-prep
+#      automation. This workflow recomputes the effective update-type and
+#      REPLACES the static `release: patch` with `release: major` when the
+#      two disagree. (Patch and minor bumps stay through the fast path:
+#      the static label is already correct.)
+#
+# Effective-update-type derivation mirrors `dependabot-auto-merge.yaml` so
+# SHA→SHA same-version dogfood self-reference bumps (which `fetch-metadata`
+# conservatively reports as semver-major) classify as patch here too —
+# keeping the label in lockstep with the merge policy.
+#
+# Race protection: the edit step combines `--remove-label` and `--add-label`
+# in one `gh pr edit` call where applicable, and follows with a post-edit
+# recheck that rolls back the workflow-applied label if a maintainer's
+# manual `release: *` raced into the check-then-act window. The rollback
+# only ever removes the desired label this workflow just applied, never
+# another, so a maintainer applying the *same* label we'd compute is a
+# set-semantics no-op and no rollback fires.
 
 on:
   pull_request:
@@ -77,7 +94,7 @@ jobs:
           ' <<<"$UPDATED_JSON")
           echo "update-type=$effective" >> "$GITHUB_OUTPUT"
 
-      - name: Add release label if missing
+      - name: Reconcile release label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -85,34 +102,66 @@ jobs:
         run: |
           set -euo pipefail
 
-          count_release_labels() {
+          # Map the effective update-type to the desired release label.
+          case "$UPDATE_TYPE" in
+            version-update:semver-major) desired="release: major" ;;
+            version-update:semver-minor) desired="release: minor" ;;
+            *)                            desired="release: patch" ;;
+          esac
+
+          # Inventory the current release labels on the PR. Sorted JSON array
+          # so `jq -r '.[0]'` is deterministic when exactly one is present.
+          list_release_labels() {
             gh pr view "$PR_URL" --json labels \
-              --jq '[.labels[].name | select(startswith("release: "))] | length'
+              --jq '[.labels[].name | select(startswith("release: "))] | sort'
           }
 
-          if [ "$(count_release_labels)" != "0" ]; then
-            echo "Release label already present; nothing to do."
+          current_json="$(list_release_labels)"
+          current_count=$(jq 'length' <<<"$current_json")
+
+          # Four cases to handle:
+          #   - 0 release labels  → add the desired one (security-update
+          #     backstop case: Dependabot didn't apply the static label).
+          #   - 1 label matching  → no-op (fast path: the static label from
+          #     dependabot.yaml is already correct, which is the common case
+          #     for grouped patch/minor bumps).
+          #   - 1 label mismatch  → replace it with the desired one
+          #     (standalone-semver-major correction case: the static
+          #     `release: patch` from dependabot.yaml doesn't match the
+          #     effective update-type, typically because a semver-major
+          #     bump split out of its group as a standalone PR).
+          #   - >1 labels         → maintainer applied an additional release
+          #     label manually; leave the conflict for `verify-pr-release-label`
+          #     to flag and the maintainer to triage. The workflow shouldn't
+          #     second-guess a manual override.
+          if [ "$current_count" = "0" ]; then
+            echo "No release label present; adding '$desired'."
+            gh pr edit "$PR_URL" --add-label "$desired"
+          elif [ "$current_count" = "1" ]; then
+            current=$(jq -r '.[0]' <<<"$current_json")
+            if [ "$current" = "$desired" ]; then
+              echo "Release label '$desired' already correct; nothing to do."
+              exit 0
+            fi
+            echo "Replacing '$current' with '$desired' (effective update-type: $UPDATE_TYPE)."
+            gh pr edit "$PR_URL" --add-label "$desired" --remove-label "$current"
+          else
+            echo "::warning::PR has multiple release labels ($(jq -c '.' <<<"$current_json")); leaving as-is for manual triage."
             exit 0
           fi
 
-          case "$UPDATE_TYPE" in
-            version-update:semver-major) label="release: major" ;;
-            version-update:semver-minor) label="release: minor" ;;
-            *)                            label="release: patch" ;;
-          esac
-
-          gh pr edit "$PR_URL" --add-label "$label"
-
-          # Post-add recheck closes the check-then-act window left by the
-          # pre-add query above. If a maintainer applied a different
-          # `release: *` label between that query and `gh pr edit --add-label`,
+          # Post-edit recheck closes the check-then-act window left by the
+          # state query above. If a maintainer applied a different
+          # `release: *` label between that query and the `gh pr edit` call,
           # the PR now carries two release labels and `verify-pr-release-label`
-          # would reject it. Roll back the label this workflow added so the
-          # manual override wins. We only ever remove `$label` (the one we
-          # just added) — never another label — so a concurrent automation
-          # that applied the *same* label produces a single label by set
-          # semantics, the count stays at 1, and no rollback fires.
-          if [ "$(count_release_labels)" -gt 1 ]; then
-            echo "::warning::A different release label appears to have been applied during the add window; removing the workflow-applied '$label' so the manual override wins."
-            gh pr edit "$PR_URL" --remove-label "$label"
+          # would reject it. Roll back the label this workflow just applied
+          # so the manual override wins. We only ever remove `$desired`
+          # (the one we just added) — never another label — so a concurrent
+          # automation that applied the *same* label produces a single label
+          # by set semantics, the count stays at 1, and no rollback fires.
+          post_count=$(gh pr view "$PR_URL" --json labels \
+            --jq '[.labels[].name | select(startswith("release: "))] | length')
+          if [ "$post_count" -gt 1 ]; then
+            echo "::warning::A different release label appears to have been applied during the edit window; removing the workflow-applied '$desired' so the manual override wins."
+            gh pr edit "$PR_URL" --remove-label "$desired"
           fi


### PR DESCRIPTION
## Summary

- Collapses the npm `dev-dependencies` / `production-dependencies` groups into a single `npm` group, mirroring the existing `github-actions` group shape.
- Adds `update-types: [minor, patch]` to both groups so semver-major bumps arrive as standalone PRs.
- Reshapes `dependabot-release-label.yaml` so the static `release: patch` from the labels list is replaced with `release: major` on standalone semver-major PRs (closes the labelling drift the `update-types` filter would otherwise introduce).

## Why the group + update-types changes

The dev/prod npm split never branched anywhere in the workflows — `rebuild-dist` runs for every Dependabot PR regardless of dependency type, and the auto-merge / release-label / reconciler workflows operate on PR-level state, not group identity. One group per ecosystem makes the two ecosystems shape-symmetric and removes a distinction that was purely cosmetic in PR titles.

Pulling majors out of the groups makes them land as standalone PRs the auto-merge workflow's semver-major exclusion can route to manual review without dragging unrelated patch/minor bumps along. Today a single semver-major bump on any grouped dep escalates the whole group's effective update-type to major and blocks auto-merge for the whole batch.

Incidental side effect: fewer simultaneous Monday PRs (2 instead of 3), which lowers the surface for the BEHIND-after-merge cascade the dependabot-reconciler workflow (#134) handles.

## Why the release-label workflow change

`update-types: [minor, patch]` makes semver-major bumps arrive as standalone PRs. The static `labels: [..., "release: patch"]` from `dependabot.yaml` is the only label form Dependabot applies, so a standalone semver-major PR inherits `release: patch`. The original `dependabot-release-label.yaml` exited early whenever any `release: *` label was present — designed for the absent-label backstop case and unaware of mismatches — so the static `release: patch` would not be corrected. `prepare-release` would compute a patch bump for what's actually a semver-major change.

Reshape the workflow's body into a four-case state machine:

| Current release labels | Action |
|---|---|
| 0 | Add the desired label (security-update backstop case) |
| 1, matching the desired | No-op (fast path; static `release: patch` was already correct for grouped patch/minor PRs) |
| 1, not matching | Replace via combined `gh pr edit --add-label/--remove-label` (the standalone-semver-major correction case) |
| >1 | Leave for manual triage (maintainer override) |

The post-edit recheck pattern is preserved — if a maintainer races a manual label in during the edit window, the workflow rolls back its own applied label so the manual override wins.

Step renamed from "Add release label if missing" → "Reconcile release label" to reflect the expanded role. Comment block rewritten to describe both the backstop and the corrector scenarios.

A brief inline comment is added on each `release: patch` line in `dependabot.yaml` noting it as the fast-path default and pointing at the corrector workflow for the mismatch case.

## What does NOT need to change

The "effective update-type" derivation in `dependabot-auto-merge.yaml` and the existing derivation step inside `dependabot-release-label.yaml` still work correctly:

- Grouped PRs now only contain `[minor, patch]` → walk picks the most-severe of those, which is the right answer.
- Standalone self-reference PRs are still SHA→SHA same-version → the `prevVersion == newVersion` filter still strips them and falls to patch.
- Standalone major PRs (newly possible from any dep) → the walk reports major, the semver-major exclusion routes to manual review on the auto-merge side, and this PR's release-label workflow change ensures the label matches.

No semantic change to `dependabot-auto-merge.yaml`.

## Test plan

- [ ] After merge, watch next Monday's Dependabot run produce one `npm` group PR and one `github-actions` group PR instead of three.
- [ ] On the next available semver-major bump (e.g., a `typescript` major or `codeql-action` major), verify it arrives as a standalone PR.
- [ ] Verify the standalone semver-major PR ends up with `release: major` (not the static `release: patch`) once `dependabot-release-label.yaml` runs.
- [ ] Verify the existing semver-major exclusion path in `dependabot-auto-merge.yaml` still routes the standalone major to manual review (no unexpected auto-merge enable).
- [ ] Verify a grouped patch/minor PR keeps `release: patch` via the fast path (no-op log line from the release-label workflow).
