### PR TITLE
ci: migrate rebuild-dist to oss-automation-bot identity

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -117,7 +117,18 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Walk the diff under dist/ and split into additions/deletions.
+          # Stage everything under dist/ first. The detect step above uses
+          # `git status --porcelain dist/`, which reports untracked entries
+          # (`??`) — a brand-new ncc chunk or a fresh `licenses.txt` flips
+          # `changed=true`. A plain `git diff HEAD -- dist/` does NOT list
+          # untracked files, so without staging those new files would
+          # silently drop out of `fileChanges` and the mutation would land
+          # an incomplete dist/ (or reject the call outright). `git add -A
+          # dist/` lifts untracked additions into the index so the cached
+          # diff classifies them as `A`.
+          git add -A dist/
+
+          # Walk the staged diff under dist/ and split into additions/deletions.
           # `--no-renames` keeps the status set to {A,M,D} (rename status
           # `R` would produce a three-column record requiring different
           # parsing); `-z` makes records null-terminated so paths with
@@ -149,7 +160,7 @@ jobs:
                 exit 1
                 ;;
             esac
-          done < <(git diff --name-status --no-renames -z HEAD -- dist/)
+          done < <(git diff --cached --name-status --no-renames -z -- dist/)
 
           # Single GraphQL mutation. The App-installation token
           # authenticates the call so GitHub signs the resulting commit

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -85,6 +85,14 @@ jobs:
       # workflows cannot read Actions secrets and vice versa, the same
       # dual-store pattern documented for `CODEOWNER_APPROVER_TOKEN` in
       # `dependabot-reconciler.yaml`.
+      #
+      # The token is narrowed to `contents: write` only. Omitting
+      # `permission-*` inputs would mint with the App installation's
+      # full permission set; this step's two consumers — `git push` to
+      # the PR branch and `GET /users/{username}` for the bot-user
+      # lookup (a public endpoint that requires no permission scope) —
+      # both work under contents-only, so the broader scopes are
+      # avoidable privilege expansion in a Dependabot-context job.
       - name: Mint oss-automation-bot token for dist push
         if: steps.dist.outputs.changed == 'true'
         id: app-token
@@ -92,6 +100,7 @@ jobs:
         with:
           app-id: ${{ vars.AUTOMATION_APP_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Commit and push dist as oss-automation-bot
         if: steps.dist.outputs.changed == 'true'

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -124,11 +124,13 @@ jobs:
           # spaces never break the split. dist/ paths don't contain
           # spaces today, but the safe form costs nothing and removes a
           # future foot-gun.
+          #
+          # `git diff -z --name-status` emits paired NUL-separated fields
+          # per record: `<status>\0<path>\0` (NOT a single tab-joined
+          # field). Read two paired NUL-terminated fields per iteration.
           additions='[]'
           deletions='[]'
-          while IFS=$'\t' read -r -d '' record; do
-            status="${record%%$'\t'*}"
-            path="${record#*$'\t'}"
+          while IFS= read -r -d '' status && IFS= read -r -d '' path; do
             case "$status" in
               A|M)
                 # createCommitOnBranch's `FileAddition.contents` is a

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -65,56 +65,61 @@ jobs:
             echo "dist/ is already up to date; nothing to commit."
           fi
 
-      - name: Validate rebuild-dist configuration
+      # Mint a short-lived token from the `oss-automation-bot` GitHub App.
+      # Used to authenticate the rebuild-dist push and to attribute the
+      # commit to the App's bot user. Replaces the legacy stack of three
+      # Dependabot-scoped configuration items (`DEPENDABOT_REBUILD_TOKEN`,
+      # `DEPENDABOT_GPG_PRIVATE_KEY`, `DEPENDABOT_GIT_COMMITTER_NAME`,
+      # `DEPENDABOT_GIT_COMMITTER_EMAIL`) and the GPG import step. The
+      # GPG dance was historically justified as "required to satisfy
+      # main's required_signatures rule" but the repository's branch
+      # ruleset (verified against the live `Default branch` ruleset) does
+      # not include `required_signatures`, so the prior commit signatures
+      # were gratuitous; the rebuild-dist commits now land as Unverified
+      # and no ruleset rejects them. `create-github-app-token` fails the
+      # job if `vars.AUTOMATION_APP_ID` or `secrets.AUTOMATION_PRIVATE_KEY`
+      # is missing, which subsumes the prior `Validate rebuild-dist
+      # configuration` step's role. The private key must exist in BOTH
+      # the Actions and Dependabot secrets stores — Dependabot-triggered
+      # workflows cannot read Actions secrets and vice versa, the same
+      # dual-store pattern documented for `CODEOWNER_APPROVER_TOKEN` in
+      # `dependabot-reconciler.yaml`.
+      - name: Mint oss-automation-bot token for dist push
         if: steps.dist.outputs.changed == 'true'
-        env:
-          REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
-          GPG_PRIVATE_KEY: ${{ secrets.DEPENDABOT_GPG_PRIVATE_KEY }}
-          COMMITTER_NAME: ${{ vars.DEPENDABOT_GIT_COMMITTER_NAME }}
-          COMMITTER_EMAIL: ${{ vars.DEPENDABOT_GIT_COMMITTER_EMAIL }}
-        run: |
-          missing=0
-          if [ -z "$REBUILD_TOKEN" ]; then
-            echo "::error::Dependabot secret DEPENDABOT_REBUILD_TOKEN is missing — required to push the rebuilt dist/ back to the PR. Create a fine-grained PAT scoped to this repo (Contents: read/write) and store it as DEPENDABOT_REBUILD_TOKEN under Settings → Secrets and variables → Dependabot."
-            missing=1
-          fi
-          if [ -z "$GPG_PRIVATE_KEY" ]; then
-            echo "::error::Dependabot secret DEPENDABOT_GPG_PRIVATE_KEY is missing — required to sign the rebuilt dist/ commit so it satisfies main's required_signatures rule. Export an armored sign-only GPG subkey ('gpg --armor --export-secret-subkeys <subkey-id>!') and store it as DEPENDABOT_GPG_PRIVATE_KEY under Settings → Secrets and variables → Dependabot."
-            missing=1
-          fi
-          if [ -z "$COMMITTER_NAME" ]; then
-            echo "::error::Repo variable DEPENDABOT_GIT_COMMITTER_NAME is missing — required as the committer name for the signed rebuild-dist commit. Set it under Settings → Secrets and variables → Actions → Variables."
-            missing=1
-          fi
-          if [ -z "$COMMITTER_EMAIL" ]; then
-            echo "::error::Repo variable DEPENDABOT_GIT_COMMITTER_EMAIL is missing — required as the committer email for the signed rebuild-dist commit. It must match a UID on the imported GPG key and a verified email on the GitHub account that owns the public key. Set it under Settings → Secrets and variables → Actions → Variables."
-            missing=1
-          fi
-          if [ "$missing" -ne 0 ]; then
-            exit 1
-          fi
-
-      - name: Import GPG key
-        if: steps.dist.outputs.changed == 'true'
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          gpg_private_key: ${{ secrets.DEPENDABOT_GPG_PRIVATE_KEY }}
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-          git_config_global: true
-          git_committer_name: ${{ vars.DEPENDABOT_GIT_COMMITTER_NAME }}
-          git_committer_email: ${{ vars.DEPENDABOT_GIT_COMMITTER_EMAIL }}
+          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
-      - name: Commit and push dist
+      - name: Commit and push dist as oss-automation-bot
         if: steps.dist.outputs.changed == 'true'
         env:
-          REBUILD_TOKEN: ${{ secrets.DEPENDABOT_REBUILD_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+          # Resolve the App's bot user record so the commit's committer
+          # fields point at the bot's profile. The `<id>+<slug>[bot]@users.noreply.github.com`
+          # form is GitHub's canonical no-reply pattern for bot users —
+          # the numeric prefix is what links the commit to the bot's
+          # profile page in the GitHub UI; without it the commit shows
+          # the right name but isn't clickable.
+          app_user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
+          git config user.name "${APP_SLUG}[bot]"
+          git config user.email "${app_user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add dist/
           git commit -m "chore: rebuild dist after dependency update"
-          git push "https://x-access-token:${REBUILD_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
+          # Push with the App-minted token. The resulting `synchronize`
+          # event is attributed to the App identity (not GITHUB_TOKEN),
+          # so downstream required-check workflows fire on the new head
+          # — matching the reconciler's `gh pr update-branch` pattern
+          # and avoiding the GITHUB_TOKEN anti-loop suppression that
+          # would otherwise leave stale checks blocking auto-merge
+          # under `strict_required_status_checks_policy: true`.
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
 
   auto-merge:
     # Skip on label events — auto-merge is set once at open/synchronize time. If a maintainer later

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -66,20 +66,27 @@ jobs:
           fi
 
       # Mint a short-lived token from the `oss-automation-bot` GitHub App.
-      # Used to authenticate the rebuild-dist push and to attribute the
-      # commit to the App's bot user. Replaces the legacy stack of four
-      # configuration items split across two stores — two Dependabot
-      # secrets (`DEPENDABOT_REBUILD_TOKEN`, `DEPENDABOT_GPG_PRIVATE_KEY`)
-      # and two Actions variables (`DEPENDABOT_GIT_COMMITTER_NAME`,
-      # `DEPENDABOT_GIT_COMMITTER_EMAIL`) — plus the GPG import step. The
-      # GPG dance was historically justified as "required to satisfy
-      # main's required_signatures rule" but the repository's branch
-      # ruleset (verified against the live `Default branch` ruleset) does
-      # not include `required_signatures`, so the prior commit signatures
-      # were gratuitous; the rebuild-dist commits now land as Unverified
-      # and no ruleset rejects them. `create-github-app-token` fails the
-      # job if `vars.AUTOMATION_APP_ID` or `secrets.AUTOMATION_PRIVATE_KEY`
-      # is missing, which subsumes the prior `Validate rebuild-dist
+      # Used to authenticate the GraphQL `createCommitOnBranch` mutation
+      # that lands the rebuilt dist/ on the PR branch. Replaces the legacy
+      # stack of four configuration items split across two stores — two
+      # Dependabot secrets (`DEPENDABOT_REBUILD_TOKEN`,
+      # `DEPENDABOT_GPG_PRIVATE_KEY`) and two Actions variables
+      # (`DEPENDABOT_GIT_COMMITTER_NAME`, `DEPENDABOT_GIT_COMMITTER_EMAIL`)
+      # — plus the GPG import step.
+      #
+      # Why GraphQL rather than plain `git push`: pushes from an
+      # App-installation token over HTTPS authenticate the push but do
+      # NOT sign the locally-created commit, so a `git push` path would
+      # land rebuild-dist commits as Unverified. `createCommitOnBranch`
+      # creates the commit server-side under the authenticated App
+      # identity; GitHub signs commits authored via this mutation on
+      # behalf of the App, so rebuild-dist commits stay Verified just
+      # like under the prior GPG flow — without any GPG key or
+      # committer-identity configuration to manage.
+      #
+      # `create-github-app-token` fails the job if
+      # `vars.AUTOMATION_APP_ID` or `secrets.AUTOMATION_PRIVATE_KEY` is
+      # missing, which subsumes the prior `Validate rebuild-dist
       # configuration` step's role. The private key must exist in BOTH
       # the Actions and Dependabot secrets stores — Dependabot-triggered
       # workflows cannot read Actions secrets and vice versa, the same
@@ -88,11 +95,10 @@ jobs:
       #
       # The token is narrowed to `contents: write` only. Omitting
       # `permission-*` inputs would mint with the App installation's
-      # full permission set; this step's two consumers — `git push` to
-      # the PR branch and `GET /users/{username}` for the bot-user
-      # lookup (a public endpoint that requires no permission scope) —
-      # both work under contents-only, so the broader scopes are
-      # avoidable privilege expansion in a Dependabot-context job.
+      # full permission set; the sole consumer of this token is the
+      # `createCommitOnBranch` mutation, which requires `contents:
+      # write`, so broader scopes are avoidable privilege expansion in
+      # a Dependabot-context job.
       - name: Mint oss-automation-bot token for dist push
         if: steps.dist.outputs.changed == 'true'
         id: app-token
@@ -102,34 +108,72 @@ jobs:
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
           permission-contents: write
 
-      - name: Commit and push dist as oss-automation-bot
+      - name: Commit dist as oss-automation-bot via createCommitOnBranch
         if: steps.dist.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Resolve the App's bot user record so the commit's committer
-          # fields point at the bot's profile. The `<id>+<slug>[bot]@users.noreply.github.com`
-          # form is GitHub's canonical no-reply pattern for bot users —
-          # the numeric prefix is what links the commit to the bot's
-          # profile page in the GitHub UI; without it the commit shows
-          # the right name but isn't clickable.
-          app_user_id=$(gh api "/users/${APP_SLUG}[bot]" --jq .id)
-          git config user.name "${APP_SLUG}[bot]"
-          git config user.email "${app_user_id}+${APP_SLUG}[bot]@users.noreply.github.com"
-          git add dist/
-          git commit -m "chore: rebuild dist after dependency update"
-          # Push with the App-minted token. The resulting `synchronize`
-          # event is attributed to the App identity (not GITHUB_TOKEN),
-          # so downstream required-check workflows fire on the new head
-          # — matching the reconciler's `gh pr update-branch` pattern
-          # and avoiding the GITHUB_TOKEN anti-loop suppression that
-          # would otherwise leave stale checks blocking auto-merge
-          # under `strict_required_status_checks_policy: true`.
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:refs/heads/${BRANCH}"
+          # Walk the diff under dist/ and split into additions/deletions.
+          # `--no-renames` keeps the status set to {A,M,D} (rename status
+          # `R` would produce a three-column record requiring different
+          # parsing); `-z` makes records null-terminated so paths with
+          # spaces never break the split. dist/ paths don't contain
+          # spaces today, but the safe form costs nothing and removes a
+          # future foot-gun.
+          additions='[]'
+          deletions='[]'
+          while IFS=$'\t' read -r -d '' record; do
+            status="${record%%$'\t'*}"
+            path="${record#*$'\t'}"
+            case "$status" in
+              A|M)
+                # createCommitOnBranch's `FileAddition.contents` is a
+                # Base64String; `-w0` keeps the encoded blob single-line
+                # so jq's `--arg` substitution and the final JSON payload
+                # both stay valid.
+                content_b64=$(base64 -w0 "$path")
+                additions=$(jq --arg p "$path" --arg c "$content_b64" \
+                  '. + [{path: $p, contents: $c}]' <<<"$additions")
+                ;;
+              D)
+                deletions=$(jq --arg p "$path" '. + [{path: $p}]' <<<"$deletions")
+                ;;
+              *)
+                echo "::error::Unexpected git status '$status' for '$path'."
+                exit 1
+                ;;
+            esac
+          done < <(git diff --name-status --no-renames -z HEAD -- dist/)
+
+          # Single GraphQL mutation. The App-installation token
+          # authenticates the call so GitHub signs the resulting commit
+          # server-side — the rebuild-dist commit lands Verified with
+          # author/committer = oss-automation-bot[bot], no local
+          # committer config required. `expectedHeadOid` pins the parent
+          # commit: if a maintainer pushed to the branch during the
+          # build, the mutation fails rather than silently overwriting
+          # their work. The resulting `synchronize` event is attributed
+          # to the App identity (not GITHUB_TOKEN), so downstream
+          # required-check workflows fire on the new head — matching
+          # the property the reconciler exploits via `gh pr
+          # update-branch`, and avoiding the GITHUB_TOKEN anti-loop
+          # suppression that would otherwise leave stale checks blocking
+          # auto-merge under `strict_required_status_checks_policy: true`.
+          jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg head_oid "$HEAD_SHA" \
+            --argjson additions "$additions" \
+            --argjson deletions "$deletions" \
+            '{
+              query: "mutation($r:String!,$b:String!,$h:GitObjectID!,$a:[FileAddition!]!,$d:[FileDeletion!]!){createCommitOnBranch(input:{branch:{repositoryNameWithOwner:$r,branchName:$b},message:{headline:\"chore: rebuild dist after dependency update\"},fileChanges:{additions:$a,deletions:$d},expectedHeadOid:$h}){commit{oid}}}",
+              variables: {r: $repo, b: $branch, h: $head_oid, a: $additions, d: $deletions}
+            }' \
+            | gh api graphql --input - --silent
 
   auto-merge:
     # Skip on label events — auto-merge is set once at open/synchronize time. If a maintainer later

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -67,10 +67,11 @@ jobs:
 
       # Mint a short-lived token from the `oss-automation-bot` GitHub App.
       # Used to authenticate the rebuild-dist push and to attribute the
-      # commit to the App's bot user. Replaces the legacy stack of three
-      # Dependabot-scoped configuration items (`DEPENDABOT_REBUILD_TOKEN`,
-      # `DEPENDABOT_GPG_PRIVATE_KEY`, `DEPENDABOT_GIT_COMMITTER_NAME`,
-      # `DEPENDABOT_GIT_COMMITTER_EMAIL`) and the GPG import step. The
+      # commit to the App's bot user. Replaces the legacy stack of four
+      # configuration items split across two stores — two Dependabot
+      # secrets (`DEPENDABOT_REBUILD_TOKEN`, `DEPENDABOT_GPG_PRIVATE_KEY`)
+      # and two Actions variables (`DEPENDABOT_GIT_COMMITTER_NAME`,
+      # `DEPENDABOT_GIT_COMMITTER_EMAIL`) — plus the GPG import step. The
       # GPG dance was historically justified as "required to satisfy
       # main's required_signatures rule" but the repository's branch
       # ruleset (verified against the live `Default branch` ruleset) does


### PR DESCRIPTION
## Summary

- Replaces the legacy PAT + GPG stack in `dependabot-auto-merge.yaml`'s `rebuild-dist` job with a short-lived `oss-automation-bot` App-installation token, matching the identity already used by `dependabot-reconciler.yaml` for `gh pr update-branch`.
- Lands the rebuilt `dist/` via the GraphQL `createCommitOnBranch` mutation. GitHub signs commits authored via this mutation server-side on behalf of the authenticated App, so rebuild-dist commits stay **Verified** just like under the prior GPG flow — without any GPG key, committer-identity configuration, or third-party action to manage.
- Drops the `crazy-max/ghaction-import-gpg` import step, the `Validate rebuild-dist configuration` pre-check (App-token mint subsumes it), and four legacy configuration items.

## Why GraphQL rather than plain `git push`

Plain `git push` with an App-installation token over HTTPS authenticates the push but does **not** sign the locally-created commit — that path would have produced Unverified commits. Verified against the live `Default branch` ruleset (`GET /repos/.../rulesets/14709073`): no `required_signatures` rule exists, so Unverified commits on PR branches would not have been rejected by any rule. But the prior GPG flow deliberately produced Verified commits, and main's history is currently all-Verified through GitHub's own squash-merge signing; landing rebuild-dist Unverified would have regressed that traceability for cosmetic reasons the GPG flow had specifically defended.

`createCommitOnBranch` creates the commit server-side under the authenticated App identity, with the bonus of `expectedHeadOid` concurrency safety (the mutation fails 422 instead of silently overwriting a concurrent maintainer push during the build).

## Net config delta

**Pre-merge — add to GitHub config:**
- `secrets.AUTOMATION_PRIVATE_KEY` must exist in the **Dependabot** secrets store in addition to the Actions store. Dependabot-triggered workflows cannot read Actions secrets and vice versa — same dual-store pattern documented for `CODEOWNER_APPROVER_TOKEN` in the reconciler.

**Post-merge — safe to remove from GitHub config:**
- Dependabot secrets: `DEPENDABOT_REBUILD_TOKEN`, `DEPENDABOT_GPG_PRIVATE_KEY`
- Actions variables: `DEPENDABOT_GIT_COMMITTER_NAME`, `DEPENDABOT_GIT_COMMITTER_EMAIL`

## Token permissions

The App token is narrowed to `contents: write` only via `permission-contents: write` on `actions/create-github-app-token`. The sole consumer of this token is the `createCommitOnBranch` mutation, which requires `contents: write`; omitting `permission-*` inputs would mint with the App installation's full permission set, an avoidable privilege expansion in a Dependabot-context job.

## How the rebuild-dist payload is built

1. `git add -A dist/` stages everything under `dist/`, including untracked entries. The detect-changes step uses `git status --porcelain dist/` which reports untracked (`??`) entries, so `changed=true` can fire on a build that produced a brand-new ncc chunk or a fresh `licenses.txt`. A naked `git diff HEAD -- dist/` would not list those, so without staging they would silently drop out of `fileChanges`.
2. `git diff --cached --name-status --no-renames -z -- dist/` enumerates the staged diff. `-z` emits paired NUL-separated fields per record — `<status>\0<path>\0` — read via `while IFS= read -r -d '' status && IFS= read -r -d '' path`. `--no-renames` keeps the status set to {A, M, D}.
3. `A|M` entries are base64-encoded and appended to `additions`; `D` entries are appended to `deletions`.
4. A single `gh api graphql` call invokes `createCommitOnBranch` with the additions/deletions and `expectedHeadOid` pinned to the PR head SHA.

## Why the synchronize event still fires required checks

The mutation runs under the `oss-automation-bot` identity (not `GITHUB_TOKEN`), so the resulting `synchronize` event is not subject to GitHub's anti-loop suppression. Downstream required-check workflows (`verify-dist`, `test`, `actionlint`, `verify-pr-release-label`) fire on the new head exactly as they would for any non-Actions push — matching the property the reconciler exploits via `gh pr update-branch`.

## Test plan

### What cannot be exercised on this PR

The `rebuild-dist` job is gated by `if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository`. This PR is maintainer-authored, so the job skips entirely in CI. The new code path (App-token mint → `git add -A` → `git diff --cached -z` → `createCommitOnBranch`) cannot be validated end-to-end until the next real Dependabot PR opens against this repo. The workflow has no `workflow_dispatch` trigger, so there is no in-repo manual harness to exercise it earlier — adding one is listed under Follow-ups.

### Pre-merge

- [x] `AUTOMATION_PRIVATE_KEY` exists in the **Dependabot** secrets store (in addition to the Actions store it already lives in for the reconciler). Verified via `gh api .../dependabot/secrets`.
- [x] The `oss-automation-bot` GitHub App installation has `Contents: write` granted on this repo (already required by the reconciler's `gh pr update-branch`, so should already be in place). Verified via the reconciler's scheduled run at 2026-05-12T19:36 completing successfully.

### Post-merge — modify-only path (exercises the parser fix `cd392b5`)

First Dependabot PR whose build produces **modifications** to existing files in `dist/` (the common case — e.g., an `openai` SDK patch bump that re-bundles `dist/publish/main.js` but adds no new chunk). Confirm in the run logs:

- [ ] `Mint oss-automation-bot token for dist push` succeeds; the minted token carries `contents: write` only.
- [ ] `Commit dist as oss-automation-bot via createCommitOnBranch` exits 0. Each modified file under `dist/` flows through the `A|M` branch of the case statement (i.e., the paired-NUL `read` loop classifies real `git diff --cached -z` records correctly).
- [ ] The PR's commits tab shows a new commit attributed to `oss-automation-bot[bot]` with a **Verified** badge (GitHub server-signed via the GraphQL mutation, per the docs cited above).
- [ ] The mutation push fires a fresh `synchronize` event on which `verify-dist` re-runs and turns green.
- [ ] `auto-merge` job proceeds: required checks pass → synchronous squash-merge fires under `GITHUB_TOKEN`, or falls back to GitHub auto-merge if `reviewDecision != APPROVED`. PR ends up `MERGED`.

### Post-merge — new-file path (exercises the staging fix `066d87b`)

Whenever a Dependabot PR happens to produce a build that **introduces a brand-new file** in `dist/` (rare — typically an `@vercel/ncc` upgrade that splits/renames chunks, or an updated dependency that adds entries to `licenses.txt`). Confirm:

- [ ] The new file appears in the rebuild-dist commit on the PR branch (i.e., it was successfully staged by `git add -A dist/` and classified as `A` by the cached diff).
- [ ] `verify-dist` on `main` after merge does not report drift — the committed `dist/` actually contains the new file.

If a real Dependabot PR exercising this path doesn't appear in a reasonable window, an explicit validation is to manually re-create the case on a throwaway branch: stale `dist/`, run `npm run build`, observe that `git status --porcelain dist/` lists at least one `??` entry, then trace through the workflow's bash locally with `bash -x` substituting the env vars by hand. Not necessary if a real PR happens first.

### Post-merge — failure modes

- [ ] If `AUTOMATION_PRIVATE_KEY` is missing from the Dependabot store at merge time, the next Dependabot rebuild-dist run fails loudly at `Mint oss-automation-bot token for dist push` with `actions/create-github-app-token`'s standard missing-secret error. Recoverable by adding the secret; no code change needed.
- [ ] If a maintainer pushes to the Dependabot PR branch during the `npm run build` window, `createCommitOnBranch` should reject the call with a 422 because `expectedHeadOid` no longer matches HEAD. This race is hard to stage intentionally and is left **not directly verified** — relying on the documented `expectedHeadOid` semantics. If it ever does trigger in production, the workflow surfaces a clear GraphQL error and the next `synchronize` event re-runs rebuild-dist against the new head.

## Follow-ups (out of scope here)

- Hoist `COMMENT_AUTHOR_LOGIN` to env in `dependabot-reconciler.yaml` so the recreate-marker author filter survives any future migration of the comment-posting token. Tracked separately.
- Add `workflow_dispatch` (and possibly `workflow_call`) triggers to `dependabot-auto-merge.yaml` so the rebuild path can be exercised manually on a synthetic branch before the next real Dependabot PR. The current trigger set (`pull_request` only) means new bugs in this code path can only be discovered against a real dist-touching Dependabot PR.


