### PR TITLE
chore: drop stale comments from Dependabot workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -67,12 +67,10 @@ jobs:
 
       # Mint a short-lived token from the `oss-automation-bot` GitHub App.
       # Used to authenticate the GraphQL `createCommitOnBranch` mutation
-      # that lands the rebuilt dist/ on the PR branch. Replaces the legacy
-      # stack of four configuration items split across two stores — two
-      # Dependabot secrets (`DEPENDABOT_REBUILD_TOKEN`,
-      # `DEPENDABOT_GPG_PRIVATE_KEY`) and two Actions variables
-      # (`DEPENDABOT_GIT_COMMITTER_NAME`, `DEPENDABOT_GIT_COMMITTER_EMAIL`)
-      # — plus the GPG import step.
+      # that lands the rebuilt dist/ on the PR branch. Replaces a prior
+      # multi-secret + GPG-import flow that required maintaining a PAT, a
+      # GPG key, and committer-identity variables across both the Actions
+      # and Dependabot secret stores.
       #
       # Why GraphQL rather than plain `git push`: pushes from an
       # App-installation token over HTTPS authenticate the push but do

--- a/.github/workflows/dependabot-reconciler.yaml
+++ b/.github/workflows/dependabot-reconciler.yaml
@@ -211,8 +211,7 @@ jobs:
       # narrower blast radius than the Release Bot (the two-App split
       # exists so a leak of the lower-risk identity doesn't force rotation
       # of the higher-risk one). The `dependabot-auto-merge.yaml`
-      # rebuild-dist step is planned to migrate to this same Automation
-      # Bot identity in a follow-up.
+      # rebuild-dist step uses the same Automation Bot identity.
       - name: Mint oss-automation-bot token for update-branch
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1


### PR DESCRIPTION
## Summary

Two comment-only updates following the oss-automation-bot migration:

- `dependabot-auto-merge.yaml`: the rebuild-dist token mint step's comment named four legacy config items (`DEPENDABOT_REBUILD_TOKEN`, `DEPENDABOT_GPG_PRIVATE_KEY`, `DEPENDABOT_GIT_COMMITTER_NAME`, `DEPENDABOT_GIT_COMMITTER_EMAIL`) that no longer exist in the repo's secret/variable stores. Replace the enumerated list with a generic description.
- `dependabot-reconciler.yaml`: the Automation Bot mint step's comment said the auto-merge workflow's rebuild-dist step was "planned to migrate to this same Automation Bot identity in a follow-up". That migration landed in #137, so the comment now describes a steady state.

No behavior changes.

## Test plan

- [ ] CI green (actionlint + verify-prose-style + verify-pr-release-label)