### PR TITLE
chore: rename release App to oss-release-bot and adopt client-id input

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -102,7 +102,7 @@ This repository runs the action against its own pull requests via [`.github/work
 
 ## Release automation identity
 
-Release automation is performed by a dedicated GitHub App installed only on this repository. The App identity is `codex-review-action-release-bot[bot]` in audit logs and PR authorship.
+Release automation is performed by a dedicated GitHub App installed only on this repository. The App identity is `oss-release-bot[bot]` in audit logs and PR authorship.
 
 ### Permission scope
 
@@ -119,7 +119,7 @@ The App has no organization permissions, no user permissions, no webhook, and no
 
 App credentials are stored at the repo level (Settings → Secrets and variables → Actions):
 
-- `RELEASE_APP_ID` (variable) — the App's numeric ID. Not a secret; stored as a repo variable so workflows can reference it via `vars.RELEASE_APP_ID`.
+- `RELEASE_CLIENT_ID` (variable) — the App's OAuth Client ID. Not a secret; stored as a repo variable so workflows can reference it via `vars.RELEASE_CLIENT_ID` and pass it as the `client-id` input to `actions/create-github-app-token`.
 - `RELEASE_APP_PRIVATE_KEY` (secret) — the App's signing key. Release-automation workflows are expected to feed this into a token-minting Action (e.g. `actions/create-github-app-token`) to obtain short-lived installation tokens at runtime.
 
 GitHub App installation tokens expire automatically (one-hour default) and are scoped to the installation rather than to a specific workflow run, so a leaked token remains usable until expiry or explicit revocation. Release-automation workflows are expected to mint a token at job start and revoke it at job end (the default post-step behavior of `actions/create-github-app-token`); the App identity itself does not enforce that. Maintainers rotate the private key by generating a new one on the App settings page and replacing the secret value; old keys remain valid until manually revoked.

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -83,7 +83,7 @@ jobs:
       # committer-identity configuration to manage.
       #
       # `create-github-app-token` fails the job if
-      # `vars.AUTOMATION_APP_ID` or `secrets.AUTOMATION_PRIVATE_KEY` is
+      # `vars.AUTOMATION_CLIENT_ID` or `secrets.AUTOMATION_PRIVATE_KEY` is
       # missing, which subsumes the prior `Validate rebuild-dist
       # configuration` step's role. The private key must exist in BOTH
       # the Actions and Dependabot secrets stores — Dependabot-triggered
@@ -102,7 +102,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          client-id: ${{ vars.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
           permission-contents: write
 

--- a/.github/workflows/dependabot-reconciler.yaml
+++ b/.github/workflows/dependabot-reconciler.yaml
@@ -205,7 +205,7 @@ jobs:
       # `strict_required_status_checks_policy: true`.
       #
       # `release.yaml` uses the same `actions/create-github-app-token`
-      # minting shape against a different App (`codex-review-action-release-bot`,
+      # minting shape against a different App (`oss-release-bot`,
       # the Release Bot) — the cross-reference is to the pattern, not the
       # identity. This workflow consumes the Automation Bot, which has a
       # narrower blast radius than the Release Bot (the two-App split
@@ -216,7 +216,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ vars.AUTOMATION_APP_ID }}
+          client-id: ${{ vars.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
       - name: Reconcile open Dependabot PRs
@@ -235,7 +235,7 @@ jobs:
           APPROVE_TOKEN: ${{ secrets.CODEOWNER_APPROVER_TOKEN }}
           # App-minted token from the `oss-automation-bot` step above. The
           # `create-github-app-token` action fails the job if
-          # `vars.AUTOMATION_APP_ID` or `secrets.AUTOMATION_PRIVATE_KEY` is
+          # `vars.AUTOMATION_CLIENT_ID` or `secrets.AUTOMATION_PRIVATE_KEY` is
           # missing, so by the time this step runs the token is always
           # present — no fallback path needed.
           UPDATE_BRANCH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -537,7 +537,7 @@ jobs:
               # `UPDATE_BRANCH_TOKEN` is the `oss-automation-bot` App-minted
               # token from the workflow-level `app-token` step. The
               # `create-github-app-token` action fails the job upstream if
-              # `vars.AUTOMATION_APP_ID` or `secrets.AUTOMATION_PRIVATE_KEY`
+              # `vars.AUTOMATION_CLIENT_ID` or `secrets.AUTOMATION_PRIVATE_KEY`
               # is missing, so the token is guaranteed present here — no
               # fallback path needed. Using the App identity instead of
               # `GITHUB_TOKEN` ensures the resulting `synchronize` event is

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -71,7 +71,7 @@ jobs:
             echo "::error::vars.RELEASE_APP_BOT_USER_ID is empty; refusing to tag with a malformed bot email."
             exit 1
           fi
-          BOT_LOGIN="codex-review-action-release-bot[bot]"
+          BOT_LOGIN="oss-release-bot[bot]"
           git config user.name "${BOT_LOGIN}"
           git config user.email "${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           git tag "v${VERSION}" "${MERGE_SHA}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -73,7 +73,7 @@ jobs:
             echo "::error::vars.RELEASE_APP_BOT_USER_ID is empty; refusing to push the major tag with a malformed bot email."
             exit 1
           fi
-          BOT_LOGIN="codex-review-action-release-bot[bot]"
+          BOT_LOGIN="oss-release-bot[bot]"
           git config user.name "${BOT_LOGIN}"
           git config user.email "${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           TAG="${GITHUB_REF_NAME}"
@@ -94,7 +94,7 @@ jobs:
             echo "::error::vars.RELEASE_APP_BOT_USER_ID is empty; refusing to open the self-pin refresh PR with a malformed bot email."
             exit 1
           fi
-          BOT_LOGIN="codex-review-action-release-bot[bot]"
+          BOT_LOGIN="oss-release-bot[bot]"
           git config user.name "${BOT_LOGIN}"
           git config user.email "${BOT_USER_ID}+${BOT_LOGIN}@users.noreply.github.com"
           VERSION_NUM="${GITHUB_REF_NAME#v}"

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -1028,7 +1028,7 @@ export function runCli(deps: PrepareReleaseDeps = {}): number {
 
     const branch = `release/v${targetVersion}`;
     const botUserId = env.RELEASE_APP_BOT_USER_ID;
-    const botLogin = "codex-review-action-release-bot[bot]";
+    const botLogin = "oss-release-bot[bot]";
     if (!botUserId) {
       throw new Error(
         "RELEASE_APP_BOT_USER_ID env var is required (the bot user ID is needed to author commits with the canonical noreply email and to verify the release branch contains only bot commits).",


### PR DESCRIPTION
## Summary

Two coordinated GitHub App housekeeping changes:

1. **App rename**: `codex-review-action-release-bot[bot]` → `oss-release-bot[bot]` everywhere the literal appears (App ID, Client ID, private key, and bot user ID all survive the rename, so the change is purely a displayed-login swap):
   - `release.yaml` — `BOT_LOGIN` ×2
   - `release-on-merge.yaml` — `BOT_LOGIN`
   - `scripts/prepare-release.ts` — `botLogin`
   - `.github/SECURITY.md` — release-automation identity reference
   - `dependabot-reconciler.yaml` — cross-reference comment
2. **`app-id` → `client-id`**: the `actions/create-github-app-token` action emits `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` on every run. Switching every call site to `client-id: ${{ vars.*_CLIENT_ID }}` removes the warning and avoids future breakage if the action drops the legacy input. Touches the same 5 workflows (`dependabot-auto-merge`, `dependabot-reconciler`, `release`, `release-on-merge`, `prepare-release`).

## Repo-settings companion actions

- New Actions vars `AUTOMATION_CLIENT_ID` and `RELEASE_CLIENT_ID` already added (this branch references them).
- Old Actions vars `AUTOMATION_APP_ID` and `RELEASE_APP_ID` will be deleted after merge.
- App rename already executed on the GitHub side.

## Test plan

- [x] `npm test` — 617 passed
- [x] `npm run build` — clean dist (no drift)
- [x] CI green (actionlint, verify-dist, verify-pr-release-label, etc.)
- [ ] Next Dependabot PR exercises rebuild-dist and auto-merge using the new `AUTOMATION_CLIENT_ID` var
- [ ] Next release exercises prepare-release / release / release-on-merge using the new `RELEASE_CLIENT_ID` var and `oss-release-bot[bot]` git committer identity