### PR TITLE
chore: unify auto-merge auto-approval on CODEOWNER_APPROVER_TOKEN

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -281,7 +281,7 @@ jobs:
           && !contains(github.event.pull_request.labels.*.name, 'trust-boundary')
           && !contains(github.event.pull_request.labels.*.name, 'security-review-required')
         env:
-          GH_TOKEN: ${{ secrets.DEPENDABOT_APPROVE_TOKEN }}
+          GH_TOKEN: ${{ secrets.CODEOWNER_APPROVER_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         # This step is intentionally fail-open: any failure (missing token, revoked PAT,
         # insufficient PAT scope, transient GitHub API error, malformed response) emits a
@@ -301,7 +301,7 @@ jobs:
           set +e
           set -uo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::DEPENDABOT_APPROVE_TOKEN is not set — skipping auto-approval. The merge step will fall back to GitHub auto-merge, which waits for a manual code-owner approval. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and store it under Settings → Secrets and variables → Dependabot → DEPENDABOT_APPROVE_TOKEN."
+            echo "::warning::CODEOWNER_APPROVER_TOKEN is not set in the Dependabot secret store — skipping auto-approval. The merge step will fall back to GitHub auto-merge, which waits for a manual code-owner approval. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and mirror the same value under Settings → Secrets and variables → Dependabot → CODEOWNER_APPROVER_TOKEN (Dependabot-triggered workflows cannot read Actions secrets, so the Actions-store copy used by dependabot-reconciler.yaml is not visible here)."
             exit 0
           fi
           if ! label_state=$(gh pr view "$PR_URL" --json labels --jq 'any(.labels[]; .name == "trust-boundary" or .name == "security-review-required")'); then
@@ -313,7 +313,7 @@ jobs:
             exit 0
           fi
           if ! gh pr review --approve --body "Auto-approved by the Dependabot Auto-Merge workflow (non-major, no security-review label)." "$PR_URL"; then
-            echo "::warning::Failed to post auto-approval review (likely a revoked or insufficiently-scoped DEPENDABOT_APPROVE_TOKEN, or a transient GitHub API error). The merge step will fall back to GitHub auto-merge."
+            echo "::warning::Failed to post auto-approval review (likely a revoked or insufficiently-scoped CODEOWNER_APPROVER_TOKEN, or a transient GitHub API error). The merge step will fall back to GitHub auto-merge."
             exit 0
           fi
 
@@ -329,7 +329,7 @@ jobs:
       #      `gh pr view --json reviewDecision == APPROVED`, which is GitHub's own answer
       #      to "is this PR sufficiently approved per the ruleset?" — including the code-
       #      owner-review requirement. This is stricter than checking whether the auto-
-      #      approval step exited 0: if `DEPENDABOT_APPROVE_TOKEN` belongs to a non-CODEOWNER
+      #      approval step exited 0: if `CODEOWNER_APPROVER_TOKEN` belongs to a non-CODEOWNER
       #      identity, `gh pr review --approve` succeeds but `reviewDecision` stays
       #      `REVIEW_REQUIRED` and we correctly fall back instead of failing on the merge.
       #   2. Fail-closed label query. Both security-review labels (trust-boundary,

--- a/.github/workflows/dependabot-reconciler.yaml
+++ b/.github/workflows/dependabot-reconciler.yaml
@@ -17,12 +17,12 @@ name: Dependabot Reconciler
 #      this workflow now uses (and `github-actions[bot]` for the legacy
 #      GITHUB_TOKEN fallback that no longer exists in this workflow). Neither
 #      identity is `dependabot[bot]`, so the resulting workflow run executes
-#      in Actions-secrets context — the auto-merge workflow's
-#      `DEPENDABOT_APPROVE_TOKEN` (a Dependabot secret) is unreadable there
-#      and its re-approve step no-ops. This workflow holds the codeowner-
-#      approver PAT in the Actions secret store (`secrets.CODEOWNER_APPROVER_TOKEN`)
-#      so the re-approval can restore the dismissed bot review from the
-#      Actions-side context.
+#      in Actions-secrets context — the auto-merge workflow's Dependabot-store
+#      copy of `CODEOWNER_APPROVER_TOKEN` is unreadable there and its re-approve
+#      step no-ops. This workflow reads the same PAT from the Actions secret
+#      store (the codeowner-approver PAT is mirrored under the same name in
+#      both stores) so the re-approval can restore the dismissed bot review
+#      from the Actions-side context.
 #   3. Auto-merge enable that silently failed (the case `verify_auto_merge_or_terminal`
 #      in dependabot-auto-merge.yaml exists to surface) and any dropped event from
 #      transient GitHub API errors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,13 +187,13 @@ All three coexist intentionally. The exclude list is the declarative defense (fa
 
 The default-branch ruleset on `main` requires one approving code-owner review before merge. `GITHUB_TOKEN` cannot approve PRs and Dependabot cannot approve its own PRs, so without an additional approver auto-merge would never complete. To close that gap, the auto-merge job posts an approving review *before* enabling auto-merge, gated by the same set of guards above (semver-major bumps, the `openai/codex-action` exclude, and either security-review label).
 
-The approval is posted using a fine-grained PAT belonging to a code-owner, stored as the Dependabot secret **`DEPENDABOT_APPROVE_TOKEN`**. The PAT must be:
+The approval is posted using a fine-grained PAT belonging to a code-owner, stored under the canonical name **`CODEOWNER_APPROVER_TOKEN`** in **both** the Dependabot secret store (consumed by the auto-merge workflow's auto-approval step in Dependabot context) and the Actions secret store (consumed by `dependabot-reconciler.yaml`'s re-approval step, which runs from `push`/`schedule`/`workflow_run` triggers and cannot see Dependabot secrets). The same PAT value lives under both store entries — workflows triggered by Dependabot do not have access to Actions secrets and vice versa, so the dual-store mirror is structural. The PAT must be:
 
 - Scoped to this repository.
 - Granted `Pull requests: write` permission (sufficient to submit a review).
 - Owned by a user listed in [`.github/CODEOWNERS`](.github/CODEOWNERS), so the review counts toward the code-owner requirement.
 
-Configure under **Settings → Secrets and variables → Dependabot → New secret**. Workflows triggered by Dependabot do not have access to Actions secrets, so the value must live under the Dependabot scope.
+Configure under **Settings → Secrets and variables → Dependabot → New secret** *and* under **Settings → Secrets and variables → Actions → New repository secret**, using the same `CODEOWNER_APPROVER_TOKEN` name and the same PAT value in both places. Rotate both copies together when the PAT expires.
 
 When the secret is unset, the approval step emits a warning and exits cleanly — auto-merge is still enabled, but the PR waits for a manual approving review.
 


### PR DESCRIPTION
## Summary

The auto-merge workflow's auto-approval step still reads `secrets.DEPENDABOT_APPROVE_TOKEN` from the Dependabot secret store, while the reconciler workflow's re-approval step reads `secrets.CODEOWNER_APPROVER_TOKEN` from the Actions store. Both names point at the same codeowner-approver PAT and `CODEOWNER_APPROVER_TOKEN` already exists in **both** stores (Actions and Dependabot), so renaming the auto-merge env binding to the canonical name is a zero-risk rename.

## Changes

- `dependabot-auto-merge.yaml`:
  - `env.GH_TOKEN`: `secrets.DEPENDABOT_APPROVE_TOKEN` → `secrets.CODEOWNER_APPROVER_TOKEN`
  - Two warning messages and one inline comment updated to reference the new name.
- `dependabot-reconciler.yaml`: top-of-file rationale block rewritten to describe the dual-store mirror under the canonical name (the prior wording named the legacy `DEPENDABOT_APPROVE_TOKEN`).

## Companion repo-settings action

After merge, delete `DEPENDABOT_APPROVE_TOKEN` from the Dependabot secret store — nothing references it anymore. The Actions and Dependabot copies of `CODEOWNER_APPROVER_TOKEN` carry the same PAT value, so no token regeneration is needed.

## Test plan

- [ ] CI green (actionlint + verify-prose-style + verify-pr-release-label)
- [ ] Next Dependabot PR exercises the auto-approval step against `secrets.CODEOWNER_APPROVER_TOKEN` (visible in the workflow log as "Auto-approved by the Dependabot Auto-Merge workflow").