### PR TITLE
ci: harden Dependabot pipeline (concurrency + commit-message scope)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,6 +2,7 @@ version: 2
 
 updates:
   - commit-message:
+      include: "scope"
       prefix: "chore"
     directory: "/"
     package-ecosystem: "github-actions"
@@ -35,6 +36,7 @@ updates:
     target-branch: "main"
 
   - commit-message:
+      include: "scope"
       prefix: "chore"
     directory: "/"
     package-ecosystem: "npm"

--- a/.github/workflows/dependabot-release-label.yaml
+++ b/.github/workflows/dependabot-release-label.yaml
@@ -48,6 +48,14 @@ on:
       - opened
       - reopened
 
+# Queue concurrent runs on the same PR rather than cancel them. Label edits
+# are idempotent and run in 1-2 s; the post-edit recheck + rollback step
+# is non-trivial and should not be interrupted mid-flight by the next
+# `opened`/`reopened` event from `@dependabot recreate`.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 # `pull-requests: write` covers `gh pr edit --add-label/--remove-label` for
 # *existing* labels on a PR — same scope `actions/labeler` ships with. The
 # four release labels referenced below (`release: major/minor/patch/skip`)


### PR DESCRIPTION
## Summary

Two small hygiene fixes from the 2026-05-13 audit of the Dependabot release-automation pipeline. Both items are repo-internal automation (no fork-operator-visible behavior change), so they ride on `v2.1.0` final rather than deferring to a `v2.1.x` patch.

### 1. Concurrency block on `dependabot-release-label.yaml`

Adds a workflow-level `concurrency:` block keyed on `<workflow>-<pr-number>` with `cancel-in-progress: false`:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
  cancel-in-progress: false
```

`cancel-in-progress: false` (queue) is deliberate: label edits are idempotent and run in 1-2 s; cancellation mid-run is the worse outcome because it can interrupt the post-edit recheck-and-rollback step that closes the check-then-act window on a maintainer's concurrent manual label override. The auto-merge workflow's conditional-cancel pattern is right for that workflow (long-running merges where stale runs cost more than they protect), wrong here.

### 2. `commit-message.include: "scope"` on both Dependabot ecosystems

`.github/dependabot.yaml` already sets `commit-message.prefix: "chore"` on both `github-actions` and `npm` ecosystems. Adding `include: "scope"` switches Dependabot commit subjects from `chore: bump foo from X to Y` to `chore(deps): bump foo from X to Y`.

Why:

- Cleaner input for `release-on-merge.yaml`'s CHANGELOG-section assembly: the `(deps)` scope is a stable parser hint for grouping bumps under `### Dependencies` rather than `### Changed`.
- Easier `git log` skim when triaging post-merge.
- Aligns with the `chore(deps): ` convention used elsewhere (Renovate default, common NPM workflow conventions).

`dependabot-release-label.yaml`'s effective-update-type derivation is unaffected — it keys on `updated-dependencies-json` metadata, not on the commit subject.

## Verification

- `actionlint .github/workflows/dependabot-release-label.yaml` — clean.
- `ruby -r yaml -e "YAML.load_file('.github/dependabot.yaml')"` — parses cleanly (host `python3` lacks the `yaml` module on this machine, so ran the equivalent Ruby check).
- `grep -c '^      include: "scope"$' .github/dependabot.yaml` returns `2`.
- `grep -A2 '^concurrency:' .github/workflows/dependabot-release-label.yaml` shows the new block.

Post-merge smoke (item 2): the next Dependabot PR's commit subject reading `chore(deps): bump <name> from <X> to <Y>` confirms the config landed. If it still reads `chore: bump <name> from <X> to <Y>`, the YAML was rejected silently and Dependabot fell back to the prior config — inspect **Settings → Code security and analysis → Dependabot alerts → recent activity**.

## Risk and rollback

- Item 1: zero risk. Pure additive workflow-level config; no behavior change on the happy path.
- Item 2: very low risk. If Dependabot rejects the new key, the service falls back to the prior config silently (no PR created until the YAML is fixed). Recovery is a one-line revert.
- Rollback: revert this commit; no downstream consumer depends on either surface.

## Scope notes

Items 3-5 from the same audit packet are intentionally out of scope here:

- Item 3 (required-checks ruleset expansion) is a settings-only change, handled separately.
- Item 4 (planning archive update) lives in a different repository.
- Item 5 (CHANGELOG composition) is owned by `prepare-release.yaml` at tag time per the release-process convention.

No issue was filed for either item; both were tracked directly in the audit packet under `docs/repo/tickets/v2.1-automation-followups.md` in the private planning archive.