### PR TITLE
ci(release): auto-approve and auto-merge the self-pin refresh PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,8 +122,14 @@ jobs:
           else
             git push origin "${BRANCH}"
           fi
-          if gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number' | grep -q '^[0-9]'; then
-            echo "Refresh PR for ${BRANCH} already open; leaving it as-is."
+          # Scope the existing-PR check to refresh-class PRs only: same repo (`gh pr list`
+          # matches `--head BRANCH` across forks too, so a fork PR with the deterministic
+          # refresh branch name would otherwise trick this step into thinking a refresh PR
+          # already exists and skip creating the base-repo PR) and `--base main` (a stale
+          # same-repo PR with the same branch name targeting a different base must not
+          # short-circuit creation of the main-base refresh PR).
+          if gh pr list --head "${BRANCH}" --base main --state open --json number,isCrossRepository --jq 'first(.[] | select(.isCrossRepository == false) | .number) // empty' | grep -q '^[0-9]'; then
+            echo "Refresh PR for ${BRANCH} (base main, same repo) already open; leaving it as-is."
             exit 0
           fi
           LABELS="release: patch,documentation"
@@ -148,12 +154,13 @@ jobs:
       # warns and emits an empty `number` output (the downstream steps then short-circuit
       # on `outputs.number != ''`) instead of aborting the whole release job.
       #
-      # The query also filters to PRs whose head branch lives in this repo. `gh pr list
-      # --head BRANCH` matches by branch name only, so a fork PR named
+      # The query filters to refresh-class PRs only — same repo (`gh pr list --head BRANCH`
+      # matches by branch name across forks too, so a fork PR named
       # `docs/refresh-self-pins-vX.Y.Z` would otherwise be selectable here and the
-      # downstream auto-approve / auto-merge steps would target the wrong PR. The
-      # `isCrossRepository == false` predicate rejects any PR whose head ref is in a fork
-      # rather than the base repo itself.
+      # downstream auto-approve / auto-merge steps would target the wrong PR) and
+      # `--base main` (a stale same-repo PR with the same head branch targeting a different
+      # base must not be selected as the main-base refresh PR). `isCrossRepository == false`
+      # is the cross-repo predicate; `--base main` is the base-ref predicate.
       - name: Resolve self-pin refresh PR number
         id: refresh-pr
         if: ${{ !contains(github.ref_name, '-') }}
@@ -164,13 +171,13 @@ jobs:
           set -uo pipefail
           VERSION_NUM="${GITHUB_REF_NAME#v}"
           BRANCH="docs/refresh-self-pins-v${VERSION_NUM}"
-          if ! PR=$(gh pr list --head "${BRANCH}" --state open --json number,isCrossRepository --jq 'first(.[] | select(.isCrossRepository == false) | .number) // empty'); then
+          if ! PR=$(gh pr list --head "${BRANCH}" --base main --state open --json number,isCrossRepository --jq 'first(.[] | select(.isCrossRepository == false) | .number) // empty'); then
             echo "::warning::Failed to query open refresh PRs for ${BRANCH} (likely a transient gh CLI or GitHub API outage); auto-approve and auto-merge steps will no-op for this run. The refresh PR — if one was opened — remains open for manual review."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ -z "${PR}" ]; then
-            echo "No open refresh PR for ${BRANCH} on the base repo (cross-repo / fork PRs with the same branch name are ignored); auto-approve and auto-merge steps will no-op."
+            echo "No open main-base refresh PR for ${BRANCH} on the base repo (cross-repo / fork PRs and PRs targeting a non-main base are ignored); auto-approve and auto-merge steps will no-op."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -144,17 +144,24 @@ jobs:
       # Resolve the refresh PR number for the auto-approve and auto-merge steps below. This
       # runs whether the previous step opened a new PR or found an existing one (e.g. on a
       # release.yaml re-run for the same tag), and is a no-op when no diff was produced so
-      # no PR exists.
+      # no PR exists. Fail-open like the steps that follow: a transient `gh pr list` outage
+      # warns and emits an empty `number` output (the downstream steps then short-circuit
+      # on `outputs.number != ''`) instead of aborting the whole release job.
       - name: Resolve self-pin refresh PR number
         id: refresh-pr
         if: ${{ !contains(github.ref_name, '-') }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          set -euo pipefail
+          set +e
+          set -uo pipefail
           VERSION_NUM="${GITHUB_REF_NAME#v}"
           BRANCH="docs/refresh-self-pins-v${VERSION_NUM}"
-          PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+          if ! PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty'); then
+            echo "::warning::Failed to query open refresh PRs for ${BRANCH} (likely a transient gh CLI or GitHub API outage); auto-approve and auto-merge steps will no-op for this run. The refresh PR — if one was opened — remains open for manual review."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ -z "${PR}" ]; then
             echo "No open refresh PR for ${BRANCH}; auto-approve and auto-merge steps will no-op."
             echo "number=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,3 +140,77 @@ jobs:
             --title "docs: refresh self-pin SHAs to v${VERSION_NUM}" \
             --label "${LABELS}" \
             --body "${BODY}"
+
+      # Resolve the refresh PR number for the auto-approve and auto-merge steps below. This
+      # runs whether the previous step opened a new PR or found an existing one (e.g. on a
+      # release.yaml re-run for the same tag), and is a no-op when no diff was produced so
+      # no PR exists.
+      - name: Resolve self-pin refresh PR number
+        id: refresh-pr
+        if: ${{ !contains(github.ref_name, '-') }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          VERSION_NUM="${GITHUB_REF_NAME#v}"
+          BRANCH="docs/refresh-self-pins-v${VERSION_NUM}"
+          PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
+          if [ -z "${PR}" ]; then
+            echo "No open refresh PR for ${BRANCH}; auto-approve and auto-merge steps will no-op."
+            echo "number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "number=${PR}" >> "$GITHUB_OUTPUT"
+
+      # Auto-approve the refresh PR so the protected-main CODEOWNER review requirement is
+      # satisfied without a manual click. The PAT in CODEOWNER_APPROVER_TOKEN belongs to a
+      # code-owner (see Settings → Secrets and variables → Actions); the App identity that
+      # opened the PR cannot approve its own PR, hence the separate token. The step is
+      # intentionally fail-open — any failure (missing token, revoked PAT, file-set guard
+      # tripped) emits a warning and exits 0, and the merge step below falls back to
+      # enabling GitHub auto-merge, which then waits for a manual code-owner approval.
+      - name: Auto-approve self-pin refresh PR
+        if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.CODEOWNER_APPROVER_TOKEN }}
+          PR: ${{ steps.refresh-pr.outputs.number }}
+        run: |
+          set +e
+          set -uo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::CODEOWNER_APPROVER_TOKEN is not set in the Actions secret store — skipping auto-approval. The merge step will fall back to enabling GitHub auto-merge, which waits for a manual code-owner approval. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and mirror the same value under Settings → Secrets and variables → Actions → CODEOWNER_APPROVER_TOKEN (Dependabot-triggered workflows read from the Dependabot secret store, so the existing copy used by dependabot-auto-merge.yaml is not visible here)."
+            exit 0
+          fi
+          if ! changed=$(gh pr diff "${PR}" --name-only); then
+            echo "::warning::Failed to read the changed file set on PR #${PR}; skipping auto-approval. The merge step will fall back to enabling GitHub auto-merge."
+            exit 0
+          fi
+          if echo "${changed}" | grep -Ev '^(README\.md|\.github/workflows/codex-review\.yaml)$' >/dev/null; then
+            echo "::warning::Refresh PR #${PR} touches files outside the whitelist (README.md, .github/workflows/codex-review.yaml); skipping auto-approval and refusing to enable auto-merge. Investigate before merging — refresh-self-pins.ts may have regressed:"
+            echo "${changed}" | awk '{print "  " $0}'
+            exit 0
+          fi
+          if ! gh pr review --approve --body "Auto-approved by release.yaml after the v${GITHUB_REF_NAME#v} tag was published. SHA-only updates to README.md and .github/workflows/codex-review.yaml were verified against the post-tag file-set whitelist; the protected-main CODEOWNER requirement is satisfied by this PAT-driven approval, which belongs to a code-owner." "${PR}"; then
+            echo "::warning::Failed to post auto-approval review on PR #${PR} (likely a revoked or insufficiently-scoped CODEOWNER_APPROVER_TOKEN, or a transient GitHub API error). The merge step will fall back to enabling GitHub auto-merge."
+            exit 0
+          fi
+
+      # Enable GitHub's auto-merge primitive on the refresh PR so the PR squash-merges as
+      # soon as required status checks pass (and an APPROVED review is recorded — by the
+      # step above on the happy path, or by a manual code-owner approval on the fallback
+      # path). Independent of auto-approval: if the previous step warned and skipped, this
+      # step still arms auto-merge so a later manual approval fires the merge without
+      # further intervention. The step is also fail-open — a `gh pr merge --auto` failure
+      # warns and exits 0, leaving the PR open for manual merge.
+      - name: Enable auto-merge on self-pin refresh PR
+        if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.refresh-pr.outputs.number }}
+        run: |
+          set +e
+          set -uo pipefail
+          if ! gh pr merge --auto --squash --delete-branch "${PR}"; then
+            echo "::warning::Failed to enable auto-merge on PR #${PR} (likely an App-token scope mismatch, a transient GitHub API error, or auto-merge disabled at the repo level — Settings → General → Pull Requests → Allow auto-merge). The PR remains open; merge it manually once CI is green."
+            exit 0
+          fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,10 +169,15 @@ jobs:
       # intentionally fail-open for transport failures (missing token, revoked PAT,
       # transient API errors): those emit a warning and exit 0, and the merge step below
       # still arms GitHub auto-merge, which then waits for a manual code-owner approval.
-      # The file-set whitelist trip is the one exception: it emits `guard_ok=false` on
-      # `$GITHUB_OUTPUT`, which the merge step gates on, so a refresh PR that touches
-      # non-whitelisted files never auto-merges — neither via an existing approval nor via
-      # a later manual one. Investigate refresh-self-pins.ts before merging it by hand.
+      # Two safety-class failures emit `guard_ok=false` on `$GITHUB_OUTPUT`, which the
+      # merge step gates on, so the refresh PR never auto-merges — neither via an
+      # existing approval nor via a later manual one:
+      #   1. file-set whitelist trip — diff touches files other than the two known
+      #      self-pin targets, indicating refresh-self-pins.ts pushed unexpected files;
+      #   2. unified-diff content check trip — diff includes line-level changes that are
+      #      not SHA-pin or SHA-tag-note bumps, indicating refresh-self-pins.ts smuggled
+      #      non-SHA edits into a whitelisted file.
+      # On either trip, investigate refresh-self-pins.ts before merging by hand.
       - name: Auto-approve self-pin refresh PR
         id: approve-refresh
         if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' }}
@@ -196,7 +201,23 @@ jobs:
             echo "guard_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if ! gh pr review --approve --body "Auto-approved by release.yaml after the v${GITHUB_REF_NAME#v} tag was published. SHA-only updates to README.md and .github/workflows/codex-review.yaml were verified against the post-tag file-set whitelist; the protected-main CODEOWNER requirement is satisfied by this PAT-driven approval, which belongs to a code-owner." "${PR}"; then
+          # Filename whitelisting is not enough — `.github/workflows/codex-review.yaml` is
+          # executable CI config. Validate that every changed line in the PR's diff is
+          # either a self-pin SHA bump or a SHA-tag-note version bump, with all other
+          # characters identical between the removed and added sides. A regression in
+          # refresh-self-pins.ts that smuggles non-SHA edits into a whitelisted file
+          # trips this check and blocks both auto-approval and auto-merge.
+          if ! diff_text=$(gh pr diff "${PR}"); then
+            echo "::warning::Failed to read the unified diff for PR #${PR}; skipping auto-approval and refusing to enable auto-merge."
+            echo "guard_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! printf '%s' "${diff_text}" | npx --no-install tsx scripts/validate-self-pin-diff.ts; then
+            echo "::warning::Refresh PR #${PR} diff contains changes outside the expected SHA-pin / tag-comment refresh; skipping auto-approval and refusing to enable auto-merge. Investigate before merging — refresh-self-pins.ts may have regressed."
+            echo "guard_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! gh pr review --approve --body "Auto-approved by release.yaml after the v${GITHUB_REF_NAME#v} tag was published. SHA-only updates to README.md and .github/workflows/codex-review.yaml were verified against the post-tag file-set whitelist and a unified-diff content check that asserts every changed line is a self-pin SHA bump or a SHA-tag-note version bump; the protected-main CODEOWNER requirement is satisfied by this PAT-driven approval, which belongs to a code-owner." "${PR}"; then
             echo "::warning::Failed to post auto-approval review on PR #${PR} (likely a revoked or insufficiently-scoped CODEOWNER_APPROVER_TOKEN, or a transient GitHub API error). The merge step will fall back to enabling GitHub auto-merge."
             exit 0
           fi
@@ -207,9 +228,10 @@ jobs:
       # path). Independent of auto-approval for transport failures: if the previous step
       # warned and skipped because of a missing/revoked token or a transient API error,
       # this step still arms auto-merge so a later manual approval fires the merge without
-      # further intervention. The file-set whitelist trip is the only blocking failure
-      # — the approve step emits `guard_ok=false` on that path and this step's condition
-      # below refuses to arm auto-merge, so a refresh PR with non-whitelisted files never
+      # further intervention. The safety-class failures (file-set whitelist trip and
+      # unified-diff content-check trip) are the blocking ones — the approve step emits
+      # `guard_ok=false` on those paths and this step's condition below refuses to arm
+      # auto-merge, so a refresh PR with non-SHA changes or non-whitelisted files never
       # auto-merges. The step itself is also fail-open — a `gh pr merge --auto` failure
       # warns and exits 0, leaving the PR open for manual merge.
       - name: Enable auto-merge on self-pin refresh PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -166,10 +166,15 @@ jobs:
       # satisfied without a manual click. The PAT in CODEOWNER_APPROVER_TOKEN belongs to a
       # code-owner (see Settings → Secrets and variables → Actions); the App identity that
       # opened the PR cannot approve its own PR, hence the separate token. The step is
-      # intentionally fail-open — any failure (missing token, revoked PAT, file-set guard
-      # tripped) emits a warning and exits 0, and the merge step below falls back to
-      # enabling GitHub auto-merge, which then waits for a manual code-owner approval.
+      # intentionally fail-open for transport failures (missing token, revoked PAT,
+      # transient API errors): those emit a warning and exit 0, and the merge step below
+      # still arms GitHub auto-merge, which then waits for a manual code-owner approval.
+      # The file-set whitelist trip is the one exception: it emits `guard_ok=false` on
+      # `$GITHUB_OUTPUT`, which the merge step gates on, so a refresh PR that touches
+      # non-whitelisted files never auto-merges — neither via an existing approval nor via
+      # a later manual one. Investigate refresh-self-pins.ts before merging it by hand.
       - name: Auto-approve self-pin refresh PR
+        id: approve-refresh
         if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' }}
         env:
           GH_TOKEN: ${{ secrets.CODEOWNER_APPROVER_TOKEN }}
@@ -188,6 +193,7 @@ jobs:
           if echo "${changed}" | grep -Ev '^(README\.md|\.github/workflows/codex-review\.yaml)$' >/dev/null; then
             echo "::warning::Refresh PR #${PR} touches files outside the whitelist (README.md, .github/workflows/codex-review.yaml); skipping auto-approval and refusing to enable auto-merge. Investigate before merging — refresh-self-pins.ts may have regressed:"
             echo "${changed}" | awk '{print "  " $0}'
+            echo "guard_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ! gh pr review --approve --body "Auto-approved by release.yaml after the v${GITHUB_REF_NAME#v} tag was published. SHA-only updates to README.md and .github/workflows/codex-review.yaml were verified against the post-tag file-set whitelist; the protected-main CODEOWNER requirement is satisfied by this PAT-driven approval, which belongs to a code-owner." "${PR}"; then
@@ -198,12 +204,16 @@ jobs:
       # Enable GitHub's auto-merge primitive on the refresh PR so the PR squash-merges as
       # soon as required status checks pass (and an APPROVED review is recorded — by the
       # step above on the happy path, or by a manual code-owner approval on the fallback
-      # path). Independent of auto-approval: if the previous step warned and skipped, this
-      # step still arms auto-merge so a later manual approval fires the merge without
-      # further intervention. The step is also fail-open — a `gh pr merge --auto` failure
+      # path). Independent of auto-approval for transport failures: if the previous step
+      # warned and skipped because of a missing/revoked token or a transient API error,
+      # this step still arms auto-merge so a later manual approval fires the merge without
+      # further intervention. The file-set whitelist trip is the only blocking failure
+      # — the approve step emits `guard_ok=false` on that path and this step's condition
+      # below refuses to arm auto-merge, so a refresh PR with non-whitelisted files never
+      # auto-merges. The step itself is also fail-open — a `gh pr merge --auto` failure
       # warns and exits 0, leaving the PR open for manual merge.
       - name: Enable auto-merge on self-pin refresh PR
-        if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' }}
+        if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' && steps.approve-refresh.outputs.guard_ok != 'false' }}
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR: ${{ steps.refresh-pr.outputs.number }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -232,20 +232,26 @@ jobs:
           # Filename whitelisting is not enough — `.github/workflows/codex-review.yaml` is
           # executable CI config. Validate that every changed line in the PR's diff is
           # either a self-pin SHA bump or a SHA-tag-note version bump, with all other
-          # characters identical between the removed and added sides. A regression in
-          # refresh-self-pins.ts that smuggles non-SHA edits into a whitelisted file
-          # trips this check and blocks both auto-approval and auto-merge.
+          # characters identical between the removed and added sides. The validator is
+          # invoked in strict mode with the just-published tag's SHA and version, so the
+          # added (`+`) self-pins and tag-notes must reference exactly those values; a
+          # refresh PR that updates to any other 40-hex SHA or any other semver tag
+          # trips this check. Together with the file-set whitelist above, this blocks
+          # both regressions in refresh-self-pins.ts that smuggle non-SHA edits into a
+          # whitelisted file and regressions that refresh to the wrong commit.
+          TAG_SHA="$(git rev-parse "${GITHUB_REF_NAME}^{}")"
+          VERSION_NUM="${GITHUB_REF_NAME#v}"
           if ! diff_text=$(gh pr diff "${PR}"); then
             echo "::warning::Failed to read the unified diff for PR #${PR}; skipping auto-approval and refusing to enable auto-merge."
             echo "guard_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if ! printf '%s' "${diff_text}" | npx --no-install tsx scripts/validate-self-pin-diff.ts; then
-            echo "::warning::Refresh PR #${PR} diff contains changes outside the expected SHA-pin / tag-comment refresh; skipping auto-approval and refusing to enable auto-merge. Investigate before merging — refresh-self-pins.ts may have regressed."
+          if ! printf '%s' "${diff_text}" | npx --no-install tsx scripts/validate-self-pin-diff.ts "${TAG_SHA}" "${VERSION_NUM}"; then
+            echo "::warning::Refresh PR #${PR} diff contains changes outside the expected SHA-pin / tag-comment refresh for v${VERSION_NUM} (${TAG_SHA}); skipping auto-approval and refusing to enable auto-merge. Investigate before merging — refresh-self-pins.ts may have regressed."
             echo "guard_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if ! gh pr review --approve --body "Auto-approved by release.yaml after the v${GITHUB_REF_NAME#v} tag was published. SHA-only updates to README.md and .github/workflows/codex-review.yaml were verified against the post-tag file-set whitelist and a unified-diff content check that asserts every changed line is a self-pin SHA bump or a SHA-tag-note version bump; the protected-main CODEOWNER requirement is satisfied by this PAT-driven approval, which belongs to a code-owner." "${PR}"; then
+          if ! gh pr review --approve --body "Auto-approved by release.yaml after the v${VERSION_NUM} tag was published. SHA-only updates to README.md and .github/workflows/codex-review.yaml were verified against the post-tag file-set whitelist and a strict unified-diff content check that asserts every added self-pin references exactly ${TAG_SHA} and every added SHA-tag-note references exactly v${VERSION_NUM}; the protected-main CODEOWNER requirement is satisfied by this PAT-driven approval, which belongs to a code-owner." "${PR}"; then
             echo "::warning::Failed to post auto-approval review on PR #${PR} (likely a revoked or insufficiently-scoped CODEOWNER_APPROVER_TOKEN, or a transient GitHub API error). The merge step will fall back to enabling GitHub auto-merge."
             exit 0
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -172,19 +172,31 @@ jobs:
       # Auto-approve the refresh PR so the protected-main CODEOWNER review requirement is
       # satisfied without a manual click. The PAT in CODEOWNER_APPROVER_TOKEN belongs to a
       # code-owner (see Settings → Secrets and variables → Actions); the App identity that
-      # opened the PR cannot approve its own PR, hence the separate token. The step is
-      # intentionally fail-open for transport failures (missing token, revoked PAT,
-      # transient API errors): those emit a warning and exit 0, and the merge step below
-      # still arms GitHub auto-merge, which then waits for a manual code-owner approval.
-      # Two safety-class failures emit `guard_ok=false` on `$GITHUB_OUTPUT`, which the
-      # merge step gates on, so the refresh PR never auto-merges — neither via an
-      # existing approval nor via a later manual one:
-      #   1. file-set whitelist trip — diff touches files other than the two known
+      # opened the PR cannot approve its own PR, hence the separate token.
+      #
+      # Posture: any path where a safety check did not run to completion emits
+      # `guard_ok=false` on `$GITHUB_OUTPUT`, which the merge step gates on, so the refresh
+      # PR never auto-merges — neither via an existing approval nor via a later manual
+      # one. The maintainer must merge by hand after reviewing the diff.
+      #
+      # `guard_ok=false` paths (safety check did not complete):
+      #   1. missing CODEOWNER_APPROVER_TOKEN — the action token cannot read the PR diff
+      #      under its own identity (the PAT is required for both approval and for
+      #      reading the diff under a code-owner identity);
+      #   2. `gh pr diff --name-only` transport failure — the file-set whitelist could
+      #      not be evaluated;
+      #   3. file-set whitelist trip — diff touches files other than the two known
       #      self-pin targets, indicating refresh-self-pins.ts pushed unexpected files;
-      #   2. unified-diff content check trip — diff includes line-level changes that are
+      #   4. `gh pr diff` transport failure — the unified-diff content check could
+      #      not be evaluated;
+      #   5. unified-diff content check trip — diff includes line-level changes that are
       #      not SHA-pin or SHA-tag-note bumps, indicating refresh-self-pins.ts smuggled
       #      non-SHA edits into a whitelisted file.
-      # On either trip, investigate refresh-self-pins.ts before merging by hand.
+      #
+      # `guard_ok` left unset (auto-merge still arms; manual approval can fire it):
+      #   - `gh pr review --approve` transport failure — both safety checks already
+      #     completed cleanly; only the approval post failed, so a manual code-owner
+      #     approval is safe to substitute.
       - name: Auto-approve self-pin refresh PR
         id: approve-refresh
         if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' }}
@@ -195,11 +207,13 @@ jobs:
           set +e
           set -uo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
-            echo "::warning::CODEOWNER_APPROVER_TOKEN is not set in the Actions secret store — skipping auto-approval. The merge step will fall back to enabling GitHub auto-merge, which waits for a manual code-owner approval. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and mirror the same value under Settings → Secrets and variables → Actions → CODEOWNER_APPROVER_TOKEN (Dependabot-triggered workflows read from the Dependabot secret store, so the existing copy used by dependabot-auto-merge.yaml is not visible here)."
+            echo "::warning::CODEOWNER_APPROVER_TOKEN is not set in the Actions secret store — skipping auto-approval and refusing to enable auto-merge because the file-set whitelist and content checks cannot run without a code-owner identity. The PR remains open for a manual review + merge until the PAT is configured. Configure a fine-grained PAT scoped to this repo (Pull requests: write) belonging to a code-owner and mirror the same value under Settings → Secrets and variables → Actions → CODEOWNER_APPROVER_TOKEN (Dependabot-triggered workflows read from the Dependabot secret store, so the existing copy used by dependabot-auto-merge.yaml is not visible here)."
+            echo "guard_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if ! changed=$(gh pr diff "${PR}" --name-only); then
-            echo "::warning::Failed to read the changed file set on PR #${PR}; skipping auto-approval. The merge step will fall back to enabling GitHub auto-merge."
+            echo "::warning::Failed to read the changed file set on PR #${PR} (likely a transient gh CLI or GitHub API outage); skipping auto-approval and refusing to enable auto-merge because the file-set whitelist could not be evaluated. The PR remains open for a manual review + merge."
+            echo "guard_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if echo "${changed}" | grep -Ev '^(README\.md|\.github/workflows/codex-review\.yaml)$' >/dev/null; then
@@ -231,16 +245,17 @@ jobs:
 
       # Enable GitHub's auto-merge primitive on the refresh PR so the PR squash-merges as
       # soon as required status checks pass (and an APPROVED review is recorded — by the
-      # step above on the happy path, or by a manual code-owner approval on the fallback
-      # path). Independent of auto-approval for transport failures: if the previous step
-      # warned and skipped because of a missing/revoked token or a transient API error,
-      # this step still arms auto-merge so a later manual approval fires the merge without
-      # further intervention. The safety-class failures (file-set whitelist trip and
-      # unified-diff content-check trip) are the blocking ones — the approve step emits
-      # `guard_ok=false` on those paths and this step's condition below refuses to arm
-      # auto-merge, so a refresh PR with non-SHA changes or non-whitelisted files never
-      # auto-merges. The step itself is also fail-open — a `gh pr merge --auto` failure
-      # warns and exits 0, leaving the PR open for manual merge.
+      # step above on the happy path, or by a manual code-owner approval on the
+      # approval-transport-failure path). This step is conditioned on
+      # `steps.approve-refresh.outputs.guard_ok != 'false'`, which means any path in the
+      # approve step where a safety check did not run to completion (missing PAT, file-set
+      # query failure, file-set whitelist trip, content-diff fetch failure, content-check
+      # trip) refuses to arm auto-merge; the maintainer must merge by hand after reviewing
+      # the diff. Only an approval-post transport failure (safety checks completed
+      # cleanly, only the `gh pr review` call failed) leaves `guard_ok` unset so this
+      # step still arms auto-merge that a later manual approval can fire.
+      # The step itself is also fail-open — a `gh pr merge --auto` failure warns and
+      # exits 0, leaving the PR open for manual merge.
       - name: Enable auto-merge on self-pin refresh PR
         if: ${{ !contains(github.ref_name, '-') && steps.refresh-pr.outputs.number != '' && steps.approve-refresh.outputs.guard_ok != 'false' }}
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,13 @@ jobs:
       # no PR exists. Fail-open like the steps that follow: a transient `gh pr list` outage
       # warns and emits an empty `number` output (the downstream steps then short-circuit
       # on `outputs.number != ''`) instead of aborting the whole release job.
+      #
+      # The query also filters to PRs whose head branch lives in this repo. `gh pr list
+      # --head BRANCH` matches by branch name only, so a fork PR named
+      # `docs/refresh-self-pins-vX.Y.Z` would otherwise be selectable here and the
+      # downstream auto-approve / auto-merge steps would target the wrong PR. The
+      # `isCrossRepository == false` predicate rejects any PR whose head ref is in a fork
+      # rather than the base repo itself.
       - name: Resolve self-pin refresh PR number
         id: refresh-pr
         if: ${{ !contains(github.ref_name, '-') }}
@@ -157,13 +164,13 @@ jobs:
           set -uo pipefail
           VERSION_NUM="${GITHUB_REF_NAME#v}"
           BRANCH="docs/refresh-self-pins-v${VERSION_NUM}"
-          if ! PR=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty'); then
+          if ! PR=$(gh pr list --head "${BRANCH}" --state open --json number,isCrossRepository --jq 'first(.[] | select(.isCrossRepository == false) | .number) // empty'); then
             echo "::warning::Failed to query open refresh PRs for ${BRANCH} (likely a transient gh CLI or GitHub API outage); auto-approve and auto-merge steps will no-op for this run. The refresh PR — if one was opened — remains open for manual review."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           if [ -z "${PR}" ]; then
-            echo "No open refresh PR for ${BRANCH}; auto-approve and auto-merge steps will no-op."
+            echo "No open refresh PR for ${BRANCH} on the base repo (cross-repo / fork PRs with the same branch name are ignored); auto-approve and auto-merge steps will no-op."
             echo "number=" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/scripts/prepare-release.test.ts
+++ b/scripts/prepare-release.test.ts
@@ -33,6 +33,7 @@ import {
   tagCommitTimestamp,
   type PullRequest,
 } from "./prepare-release.js";
+import { SELF_REPO } from "./self-repo.js";
 
 function makePr(overrides: Partial<PullRequest> & { number: number }): PullRequest {
   return {
@@ -827,7 +828,7 @@ describe("resolveGateDocUrl", () => {
 
   it("falls back to upstream host and repository when both env vars are unset", () => {
     expect(resolveGateDocUrl({})).toBe(
-      "https://github.com/milanhorvatovic/codex-ai-code-review-action/blob/main/docs/release-gate.md",
+      `https://github.com/${SELF_REPO}/blob/main/docs/release-gate.md`,
     );
   });
 
@@ -1011,7 +1012,7 @@ describe("buildSignoffSection (with explicit gateDocUrl)", () => {
     expect(section).toContain(`(${url}#security-review-required-cross-reference)`);
     expect(section).toContain(`(${url}#security-review-sign-off)`);
     expect(section).toContain(`(${url}#archiving-the-gate)`);
-    expect(section).not.toContain("milanhorvatovic/codex-ai-code-review-action");
+    expect(section).not.toContain(SELF_REPO);
   });
 });
 
@@ -2004,6 +2005,6 @@ describe("runCli (rerun body-refresh integration)", () => {
       "https://github.fork.example/team/fork-repo/blob/trunk/docs/release-gate.md",
     );
     // Hard-coded upstream URL must NOT appear since git fallback resolved.
-    expect(bodyArg).not.toContain("milanhorvatovic/codex-ai-code-review-action");
+    expect(bodyArg).not.toContain(SELF_REPO);
   });
 });

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -13,6 +13,7 @@ import {
   removeSections,
   type VersionBump,
 } from "./changelog.js";
+import { SELF_REPO } from "./self-repo.js";
 
 export type Label = { name: string };
 
@@ -536,7 +537,6 @@ export function buildAutoHeaderSection(args: {
 // either rebase to a `main`-named default or treat the script as
 // `main`-only.
 const DEFAULT_GATE_DOC_HOST = "https://github.com";
-const DEFAULT_GATE_DOC_REPO = "milanhorvatovic/codex-ai-code-review-action";
 const DEFAULT_GATE_DOC_BRANCH = "main";
 
 export function resolveGateDocUrl(
@@ -545,7 +545,7 @@ export function resolveGateDocUrl(
   branchOverride?: string,
 ): string {
   const host = env.GITHUB_SERVER_URL ?? gitFallback?.host ?? DEFAULT_GATE_DOC_HOST;
-  const repo = env.GITHUB_REPOSITORY ?? gitFallback?.repo ?? DEFAULT_GATE_DOC_REPO;
+  const repo = env.GITHUB_REPOSITORY ?? gitFallback?.repo ?? SELF_REPO;
   const branch =
     branchOverride ??
     gitFallback?.defaultBranch ??

--- a/scripts/refresh-self-pins.test.ts
+++ b/scripts/refresh-self-pins.test.ts
@@ -8,29 +8,30 @@ import {
   rewriteShaTagNote,
   runCli,
 } from "./refresh-self-pins.js";
+import { SELF_REPO } from "./self-repo.js";
 
 const NEW_SHA = "1111111111111111111111111111111111111111";
 const OLD_SHA = "af72a5bd7330432cee97137b04d04edebde80149";
 
 describe("rewriteSelfPin", () => {
   it("rewrites a top-level self-reference", () => {
-    const line = `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`;
+    const line = `      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`;
     expect(rewriteSelfPin(line, "2.1.0", NEW_SHA)).toBe(
-      `      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
     );
   });
 
   it("rewrites a sub-action self-reference", () => {
-    const line = `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.0.0`;
+    const line = `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.0.0`;
     expect(rewriteSelfPin(line, "2.1.0", NEW_SHA)).toBe(
-      `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+      `      uses: ${SELF_REPO}/prepare@${NEW_SHA} # v2.1.0`,
     );
   });
 
   it("appends a tag comment when none was present", () => {
-    const line = `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA}`;
+    const line = `      uses: ${SELF_REPO}@${OLD_SHA}`;
     expect(rewriteSelfPin(line, "2.1.0", NEW_SHA)).toBe(
-      `      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
     );
   });
 
@@ -40,7 +41,7 @@ describe("rewriteSelfPin", () => {
   });
 
   it("leaves @v2-style floating tags untouched", () => {
-    const line = `      uses: milanhorvatovic/codex-ai-code-review-action@v2`;
+    const line = `      uses: ${SELF_REPO}@v2`;
     expect(rewriteSelfPin(line, "2.1.0", NEW_SHA)).toBe(line);
   });
 
@@ -61,9 +62,9 @@ describe("rewriteAllSelfPins", () => {
   it("rewrites every self-reference and leaves others untouched", () => {
     const content = [
       `      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`,
-      `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.0.0`,
-      `      uses: milanhorvatovic/codex-ai-code-review-action/review@${OLD_SHA} # v2.0.0`,
-      `      uses: milanhorvatovic/codex-ai-code-review-action/publish@${OLD_SHA} # v2.0.0`,
+      `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.0.0`,
+      `      uses: ${SELF_REPO}/review@${OLD_SHA} # v2.0.0`,
+      `      uses: ${SELF_REPO}/publish@${OLD_SHA} # v2.0.0`,
     ].join("\n");
     const result = rewriteAllSelfPins(content, "2.1.0", NEW_SHA);
     expect(result.split("\n")[0]).toContain("actions/checkout@");
@@ -105,7 +106,7 @@ describe("refreshReadme", () => {
     const content = [
       "# Project",
       "",
-      `      uses: milanhorvatovic/codex-ai-code-review-action/publish@${OLD_SHA} # v2.0.0`,
+      `      uses: ${SELF_REPO}/publish@${OLD_SHA} # v2.0.0`,
       `        # SHA corresponds to tag v2.0.0 — update when adopting a new release.`,
       "",
       "## Architecture",
@@ -121,9 +122,9 @@ describe("refreshReadme", () => {
 describe("refreshWorkflow", () => {
   it("rewrites every self-reference SHA and tag comment in a workflow file", () => {
     const content = [
-      `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.1.0-pre`,
-      `      uses: milanhorvatovic/codex-ai-code-review-action/review@${OLD_SHA} # v2.1.0-pre`,
-      `      uses: milanhorvatovic/codex-ai-code-review-action/publish@${OLD_SHA} # v2.1.0-pre`,
+      `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.1.0-pre`,
+      `      uses: ${SELF_REPO}/review@${OLD_SHA} # v2.1.0-pre`,
+      `      uses: ${SELF_REPO}/publish@${OLD_SHA} # v2.1.0-pre`,
     ].join("\n");
     const result = refreshWorkflow(content, "2.1.0", NEW_SHA);
     expect(result).not.toContain(OLD_SHA);
@@ -177,8 +178,8 @@ describe("runCli", () => {
   it("returns 0 and writes both targets when both have outdated SHAs", () => {
     const stub: Stub = {
       files: {
-        [README_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-        [WORKFLOW_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.1.0-pre`,
+        [README_PATH]: `      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+        [WORKFLOW_PATH]: `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.1.0-pre`,
       },
       writes: [],
       stdout: [],
@@ -194,8 +195,8 @@ describe("runCli", () => {
   it("writes only the workflow file when README is already up to date", () => {
     const stub: Stub = {
       files: {
-        [README_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
-        [WORKFLOW_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.1.0-pre`,
+        [README_PATH]: `      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+        [WORKFLOW_PATH]: `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.1.0-pre`,
       },
       writes: [],
       stdout: [],
@@ -210,8 +211,8 @@ describe("runCli", () => {
   it("writes only README when the workflow file is already up to date", () => {
     const stub: Stub = {
       files: {
-        [README_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-        [WORKFLOW_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+        [README_PATH]: `      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+        [WORKFLOW_PATH]: `      uses: ${SELF_REPO}/prepare@${NEW_SHA} # v2.1.0`,
       },
       writes: [],
       stdout: [],
@@ -226,8 +227,8 @@ describe("runCli", () => {
   it("returns 0 without writing when no edits are required across all targets", () => {
     const stub: Stub = {
       files: {
-        [README_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
-        [WORKFLOW_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+        [README_PATH]: `      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+        [WORKFLOW_PATH]: `      uses: ${SELF_REPO}/prepare@${NEW_SHA} # v2.1.0`,
       },
       writes: [],
       stdout: [],
@@ -261,7 +262,7 @@ describe("runCli", () => {
   it("does not write any target when a later read fails", () => {
     const stub: Stub = {
       files: {
-        [README_PATH]: `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+        [README_PATH]: `      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
         // WORKFLOW_PATH intentionally absent so reading it throws after README has been refreshed.
       },
       writes: [],
@@ -274,8 +275,8 @@ describe("runCli", () => {
   });
 
   it("rolls back earlier writes and the in-flight file when a later write throws", () => {
-    const readmeOriginal = `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`;
-    const workflowOriginal = `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.1.0-pre`;
+    const readmeOriginal = `      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`;
+    const workflowOriginal = `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.1.0-pre`;
     const stub: Stub = {
       files: { [README_PATH]: readmeOriginal, [WORKFLOW_PATH]: workflowOriginal },
       writes: [],
@@ -316,8 +317,8 @@ describe("runCli", () => {
   });
 
   it("surfaces the original write error when rollback writes also fail", () => {
-    const readmeOriginal = `      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`;
-    const workflowOriginal = `      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.1.0-pre`;
+    const readmeOriginal = `      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`;
+    const workflowOriginal = `      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.1.0-pre`;
     const stub: Stub = {
       files: { [README_PATH]: readmeOriginal, [WORKFLOW_PATH]: workflowOriginal },
       writes: [],

--- a/scripts/refresh-self-pins.ts
+++ b/scripts/refresh-self-pins.ts
@@ -2,9 +2,12 @@ import { readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import { parseVersion } from "./changelog.js";
+import { SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
 
-const SELF_PIN_PATTERN =
-  /(milanhorvatovic\/codex-ai-code-review-action)(\/[\w./-]+?)?@[0-9a-f]{40}(?:[ \t]*#[ \t]*[\w.+-]+)?/g;
+const SELF_PIN_PATTERN = new RegExp(
+  `(${SELF_REPO_REGEX_SOURCE})(\\/[\\w./-]+?)?@[0-9a-f]{40}(?:[ \\t]*#[ \\t]*[\\w.+-]+)?`,
+  "g",
+);
 
 const SHA_TAG_NOTE = /(# SHA corresponds to tag )v\d+\.\d+\.\d+(?:-[\w.-]+)?( — update when adopting a new release\.)/g;
 

--- a/scripts/self-repo.test.ts
+++ b/scripts/self-repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { SELF_REPO, SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
+import { escapeRegex, SELF_REPO, SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
 
 describe("SELF_REPO", () => {
   it("uses the canonical owner/repo identifier", () => {
@@ -21,5 +21,38 @@ describe("SELF_REPO_REGEX_SOURCE", () => {
   it("does not match a different owner with the same repo name", () => {
     const re = new RegExp(`^${SELF_REPO_REGEX_SOURCE}$`);
     expect(re.test("someoneelse/codex-ai-code-review-action")).toBe(false);
+  });
+});
+
+describe("escapeRegex", () => {
+  it("escapes every JS regex metacharacter so the result is RegExp-source-safe", () => {
+    expect(escapeRegex("a.b*c+d?e^f$g(h)i[j]k{l}m|n\\o/p")).toBe(
+      "a\\.b\\*c\\+d\\?e\\^f\\$g\\(h\\)i\\[j\\]k\\{l\\}m\\|n\\\\o\\/p",
+    );
+  });
+
+  it("escapes a `.` so a literal dot does not behave as a wildcard", () => {
+    const source = escapeRegex("forks/my.action");
+    const re = new RegExp(`^${source}$`);
+    expect(re.test("forks/my.action")).toBe(true);
+    // Wildcard interpretation would match "/myXaction" — escaping prevents that.
+    expect(re.test("forks/myXaction")).toBe(false);
+  });
+
+  it("escapes a backslash without producing an invalid pattern", () => {
+    const source = escapeRegex("ab\\cd");
+    expect(source).toBe("ab\\\\cd");
+    const re = new RegExp(`^${source}$`);
+    expect(re.test("ab\\cd")).toBe(true);
+  });
+
+  it("leaves non-metacharacter input unchanged", () => {
+    expect(escapeRegex("alphanumeric_dash-and_underscore")).toBe(
+      "alphanumeric_dash-and_underscore",
+    );
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(escapeRegex("")).toBe("");
   });
 });

--- a/scripts/self-repo.test.ts
+++ b/scripts/self-repo.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { SELF_REPO, SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
+
+describe("SELF_REPO", () => {
+  it("uses the canonical owner/repo identifier", () => {
+    expect(SELF_REPO).toBe("milanhorvatovic/codex-ai-code-review-action");
+  });
+});
+
+describe("SELF_REPO_REGEX_SOURCE", () => {
+  it("escapes forward slashes for safe embedding in a RegExp source string", () => {
+    expect(SELF_REPO_REGEX_SOURCE).toBe("milanhorvatovic\\/codex-ai-code-review-action");
+  });
+
+  it("produces a RegExp that matches the SELF_REPO literal exactly", () => {
+    const re = new RegExp(`^${SELF_REPO_REGEX_SOURCE}$`);
+    expect(re.test(SELF_REPO)).toBe(true);
+  });
+
+  it("does not match a different owner with the same repo name", () => {
+    const re = new RegExp(`^${SELF_REPO_REGEX_SOURCE}$`);
+    expect(re.test("someoneelse/codex-ai-code-review-action")).toBe(false);
+  });
+});

--- a/scripts/self-repo.ts
+++ b/scripts/self-repo.ts
@@ -1,0 +1,20 @@
+// Canonical identity of this repository. Centralized so a fork or rename only needs to
+// update one line — every consumer (refresh-self-pins, validate-self-pin-diff,
+// verify-doc-pins, prepare-release) imports from here.
+
+export const SELF_REPO = "milanhorvatovic/codex-ai-code-review-action";
+
+// Regex-escaped form of `SELF_REPO` for embedding inside a RegExp source string.
+// Only `/` needs escaping — the repo identifier contains no other regex metacharacters,
+// but the guard below catches any future drift that would silently produce an
+// unanchored or malformed pattern.
+function regexEscape(input: string): string {
+  if (/[.*+?^${}()|[\]\\]/.test(input)) {
+    throw new Error(
+      `SELF_REPO contains regex metacharacters that need explicit escaping: ${input}`,
+    );
+  }
+  return input.replace(/\//g, "\\/");
+}
+
+export const SELF_REPO_REGEX_SOURCE = regexEscape(SELF_REPO);

--- a/scripts/self-repo.ts
+++ b/scripts/self-repo.ts
@@ -4,17 +4,12 @@
 
 export const SELF_REPO = "milanhorvatovic/codex-ai-code-review-action";
 
-// Regex-escaped form of `SELF_REPO` for embedding inside a RegExp source string.
-// Only `/` needs escaping — the repo identifier contains no other regex metacharacters,
-// but the guard below catches any future drift that would silently produce an
-// unanchored or malformed pattern.
-function regexEscape(input: string): string {
-  if (/[.*+?^${}()|[\]\\]/.test(input)) {
-    throw new Error(
-      `SELF_REPO contains regex metacharacters that need explicit escaping: ${input}`,
-    );
-  }
-  return input.replace(/\//g, "\\/");
+// Regex-escape every JS regex metacharacter (and `/` for regex-literal compatibility) so
+// the result is safe to embed inside a `new RegExp(...)` source string regardless of
+// which valid GitHub-repo characters appear in the input. Standard `escapeRegExp`-style
+// transformation; exported for direct testing.
+export function escapeRegex(input: string): string {
+  return input.replace(/[\\^$.*+?()[\]{}|/]/g, "\\$&");
 }
 
-export const SELF_REPO_REGEX_SOURCE = regexEscape(SELF_REPO);
+export const SELF_REPO_REGEX_SOURCE = escapeRegex(SELF_REPO);

--- a/scripts/validate-self-pin-diff.test.ts
+++ b/scripts/validate-self-pin-diff.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli, validateUnifiedDiff } from "./validate-self-pin-diff.js";
+
+const OLD_SHA = "af72a5bd7330432cee97137b04d04edebde80149";
+const NEW_SHA = "1111111111111111111111111111111111111111";
+
+function buildDiff(path: string, hunk: string): string {
+  return [
+    `diff --git a/${path} b/${path}`,
+    `index abcdef1..abcdef2 100644`,
+    `--- a/${path}`,
+    `+++ b/${path}`,
+    hunk,
+  ].join("\n");
+}
+
+describe("validateUnifiedDiff", () => {
+  it("accepts a SHA-only self-pin refresh", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a tag-comment-note refresh", () => {
+    const hunk = [
+      `@@ -1,1 +1,1 @@`,
+      `-        # SHA corresponds to tag v2.0.0 — update when adopting a new release.`,
+      `+        # SHA corresponds to tag v2.1.0 — update when adopting a new release.`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff("README.md", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts multiple SHA refreshes across hunks", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       step-a:`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+      `@@ -42,3 +42,3 @@`,
+      `       step-b:`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action/review@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action/review@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a non-SHA edit alongside a SHA refresh on the same line", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0 # smuggled comment`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("rejects a line that contains no self-pin or sha-tag-note", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      timeout-minutes: 5`,
+      `+      timeout-minutes: 10`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("rejects a whitespace-only edit that masks to the same string with no pattern match", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      timeout-minutes:    5`,
+      `+      timeout-minutes:    5`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("matches no expected pattern");
+  });
+
+  it("rejects a pure addition (new line not paired with a removal)", () => {
+    const hunk = [
+      `@@ -10,3 +10,4 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `+      env: { SECRET: leak }`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("unbalanced hunk");
+  });
+
+  it("rejects a pure addition with no matching removal block", () => {
+    const hunk = [
+      `@@ -10,2 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `+      malicious: payload`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("pure addition is not a SHA-only refresh");
+  });
+
+  it("attributes errors to the right file path across multiple files", () => {
+    const okHunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+    ].join("\n");
+    const badHunk = [
+      `@@ -1,3 +1,3 @@`,
+      `       header`,
+      `-      timeout-minutes: 5`,
+      `+      timeout-minutes: 10`,
+      `       footer`,
+    ].join("\n");
+    const combined = [
+      buildDiff(".github/workflows/codex-review.yaml", okHunk),
+      buildDiff("README.md", badHunk),
+    ].join("\n");
+    const result = validateUnifiedDiff(combined);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors[0]).toContain("README.md:");
+    expect(result.errors[0]).not.toContain(".github/workflows/codex-review.yaml:");
+  });
+
+  it("returns ok for an empty diff", () => {
+    expect(validateUnifiedDiff("")).toEqual({ ok: true });
+  });
+});
+
+describe("runCli", () => {
+  it("returns 0 for a SHA-only diff", () => {
+    const stderr: string[] = [];
+    const text = [
+      `diff --git a/README.md b/README.md`,
+      `--- a/README.md`,
+      `+++ b/README.md`,
+      `@@ -1,1 +1,1 @@`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const exit = runCli({
+      readInput: () => text,
+      stderrWrite: (chunk) => stderr.push(chunk),
+    });
+    expect(exit).toBe(0);
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("returns 1 and writes errors to stderr for a non-SHA edit", () => {
+    const stderr: string[] = [];
+    const text = [
+      `diff --git a/README.md b/README.md`,
+      `--- a/README.md`,
+      `+++ b/README.md`,
+      `@@ -1,1 +1,1 @@`,
+      `-      timeout: 5`,
+      `+      timeout: 10`,
+    ].join("\n");
+    const exit = runCli({
+      readInput: () => text,
+      stderrWrite: (chunk) => stderr.push(chunk),
+    });
+    expect(exit).toBe(1);
+    expect(stderr.join("")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+});

--- a/scripts/validate-self-pin-diff.test.ts
+++ b/scripts/validate-self-pin-diff.test.ts
@@ -260,6 +260,112 @@ describe("validateUnifiedDiff", () => {
   });
 });
 
+describe("validateUnifiedDiff diff-section hardening", () => {
+  it("rejects a file-mode change (old mode / new mode headers)", () => {
+    const text = [
+      `diff --git a/.github/workflows/codex-review.yaml b/.github/workflows/codex-review.yaml`,
+      `old mode 100644`,
+      `new mode 100755`,
+      `index abcdef1..abcdef2 100755`,
+      `--- a/.github/workflows/codex-review.yaml`,
+      `+++ b/.github/workflows/codex-review.yaml`,
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("file mode change is not a SHA-only refresh");
+  });
+
+  it("rejects a new-file diff section (new file mode header)", () => {
+    const text = [
+      `diff --git a/.github/workflows/new.yaml b/.github/workflows/new.yaml`,
+      `new file mode 100644`,
+      `index 0000000..abcdef1`,
+      `--- /dev/null`,
+      `+++ b/.github/workflows/new.yaml`,
+      `@@ -0,0 +1,1 @@`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("file mode change is not a SHA-only refresh");
+  });
+
+  it("rejects a file rename diff section", () => {
+    const text = [
+      `diff --git a/README.md b/RENAMED.md`,
+      `similarity index 100%`,
+      `rename from README.md`,
+      `rename to RENAMED.md`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("file rename/copy is not a SHA-only refresh");
+  });
+
+  it("rejects a binary diff (`Binary files ... differ`)", () => {
+    const text = [
+      `diff --git a/assets/logo.png b/assets/logo.png`,
+      `index abcdef1..abcdef2 100644`,
+      `Binary files a/assets/logo.png and b/assets/logo.png differ`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("binary patch is not a SHA-only refresh");
+  });
+
+  it("rejects a GIT binary patch diff section", () => {
+    const text = [
+      `diff --git a/assets/logo.png b/assets/logo.png`,
+      `index abcdef1..abcdef2 100644`,
+      `GIT binary patch`,
+      `literal 12`,
+      `Mc$_NA01R$#mH+?%`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("binary patch is not a SHA-only refresh");
+  });
+
+  it("rejects a header-only diff section that has no hunks at all", () => {
+    const text = [
+      `diff --git a/.github/workflows/codex-review.yaml b/.github/workflows/codex-review.yaml`,
+      `index abcdef1..abcdef2 100644`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("diff section has no hunks");
+  });
+
+  it("rejects when a no-hunk section precedes a valid SHA-only section", () => {
+    const text = [
+      `diff --git a/assets/logo.png b/assets/logo.png`,
+      `index abcdef1..abcdef2 100644`,
+      `diff --git a/.github/workflows/codex-review.yaml b/.github/workflows/codex-review.yaml`,
+      `index abcdef1..abcdef2 100644`,
+      `--- a/.github/workflows/codex-review.yaml`,
+      `+++ b/.github/workflows/codex-review.yaml`,
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const result = validateUnifiedDiff(text);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("diff section has no hunks");
+    // The valid second section should not contribute additional errors.
+    expect(result.errors.length).toBe(1);
+  });
+});
+
 describe("validateUnifiedDiff strict mode (expectedSha + expectedVersion)", () => {
   const EXPECTED_VERSION = "2.1.0";
 

--- a/scripts/validate-self-pin-diff.test.ts
+++ b/scripts/validate-self-pin-diff.test.ts
@@ -260,6 +260,122 @@ describe("validateUnifiedDiff", () => {
   });
 });
 
+describe("validateUnifiedDiff strict mode (expectedSha + expectedVersion)", () => {
+  const EXPECTED_VERSION = "2.1.0";
+
+  it("accepts a SHA-only refresh whose added side matches the expected SHA and version", () => {
+    const hunk = [
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v${EXPECTED_VERSION}`,
+    ].join("\n");
+    const result = validateUnifiedDiff(
+      buildDiff(".github/workflows/codex-review.yaml", hunk),
+      { expectedSha: NEW_SHA, expectedVersion: EXPECTED_VERSION },
+    );
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a refresh whose added SHA does not match the expected SHA", () => {
+    const WRONG_SHA = "2222222222222222222222222222222222222222";
+    const hunk = [
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${WRONG_SHA} # v${EXPECTED_VERSION}`,
+    ].join("\n");
+    const result = validateUnifiedDiff(
+      buildDiff(".github/workflows/codex-review.yaml", hunk),
+      { expectedSha: NEW_SHA, expectedVersion: EXPECTED_VERSION },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("rejects a refresh whose added tag does not match the expected version", () => {
+    const hunk = [
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v9.9.9`,
+    ].join("\n");
+    const result = validateUnifiedDiff(
+      buildDiff(".github/workflows/codex-review.yaml", hunk),
+      { expectedSha: NEW_SHA, expectedVersion: EXPECTED_VERSION },
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("accepts a SHA-tag-note refresh whose added version matches the expected version", () => {
+    const hunk = [
+      `@@ -1,1 +1,1 @@`,
+      `-        # SHA corresponds to tag v2.0.0 — update when adopting a new release.`,
+      `+        # SHA corresponds to tag v${EXPECTED_VERSION} — update when adopting a new release.`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff("README.md", hunk), {
+      expectedSha: NEW_SHA,
+      expectedVersion: EXPECTED_VERSION,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("rejects a SHA-tag-note refresh whose added version does not match the expected version", () => {
+    const hunk = [
+      `@@ -1,1 +1,1 @@`,
+      `-        # SHA corresponds to tag v2.0.0 — update when adopting a new release.`,
+      `+        # SHA corresponds to tag v9.9.9 — update when adopting a new release.`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff("README.md", hunk), {
+      expectedSha: NEW_SHA,
+      expectedVersion: EXPECTED_VERSION,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("throws when only expectedSha is provided", () => {
+    expect(() =>
+      validateUnifiedDiff("", { expectedSha: NEW_SHA }),
+    ).toThrow(/pass both expectedSha and expectedVersion, or neither/);
+  });
+
+  it("throws when only expectedVersion is provided", () => {
+    expect(() =>
+      validateUnifiedDiff("", { expectedVersion: EXPECTED_VERSION }),
+    ).toThrow(/pass both expectedSha and expectedVersion, or neither/);
+  });
+
+  it("throws when expectedSha is not a 40-character lowercase hex string", () => {
+    const hunk = [
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v${EXPECTED_VERSION}`,
+    ].join("\n");
+    expect(() =>
+      validateUnifiedDiff(buildDiff("README.md", hunk), {
+        expectedSha: "not-a-sha",
+        expectedVersion: EXPECTED_VERSION,
+      }),
+    ).toThrow(/40-character lowercase hex string/);
+  });
+
+  it("throws when expectedVersion is not a semver string", () => {
+    const hunk = [
+      `@@ -10,1 +10,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v${EXPECTED_VERSION}`,
+    ].join("\n");
+    expect(() =>
+      validateUnifiedDiff(buildDiff("README.md", hunk), {
+        expectedSha: NEW_SHA,
+        expectedVersion: "vNOT.semver",
+      }),
+    ).toThrow(/MAJOR\.MINOR\.PATCH/);
+  });
+});
+
 describe("runCli", () => {
   it("returns 0 for a SHA-only diff", () => {
     const stderr: string[] = [];
@@ -295,5 +411,74 @@ describe("runCli", () => {
     });
     expect(exit).toBe(1);
     expect(stderr.join("")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("returns 0 when strict-mode argv matches the diff's added SHA and version", () => {
+    const stderr: string[] = [];
+    const text = [
+      `diff --git a/README.md b/README.md`,
+      `--- a/README.md`,
+      `+++ b/README.md`,
+      `@@ -1,1 +1,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const exit = runCli({
+      argv: [NEW_SHA, "2.1.0"],
+      readInput: () => text,
+      stderrWrite: (chunk) => stderr.push(chunk),
+    });
+    expect(exit).toBe(0);
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("returns 1 when strict-mode argv disagrees with the diff's added SHA", () => {
+    const WRONG_SHA = "2222222222222222222222222222222222222222";
+    const stderr: string[] = [];
+    const text = [
+      `diff --git a/README.md b/README.md`,
+      `--- a/README.md`,
+      `+++ b/README.md`,
+      `@@ -1,1 +1,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${WRONG_SHA} # v2.1.0`,
+    ].join("\n");
+    const exit = runCli({
+      argv: [NEW_SHA, "2.1.0"],
+      readInput: () => text,
+      stderrWrite: (chunk) => stderr.push(chunk),
+    });
+    expect(exit).toBe(1);
+    expect(stderr.join("")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("returns 1 and prints usage when argv has exactly one argument", () => {
+    const stderr: string[] = [];
+    const exit = runCli({
+      argv: [NEW_SHA],
+      readInput: () => "",
+      stderrWrite: (chunk) => stderr.push(chunk),
+    });
+    expect(exit).toBe(1);
+    expect(stderr.join("")).toContain("Usage:");
+  });
+
+  it("returns 1 and surfaces validateUnifiedDiff's error for an invalid expected-sha argv", () => {
+    const stderr: string[] = [];
+    const text = [
+      `diff --git a/README.md b/README.md`,
+      `--- a/README.md`,
+      `+++ b/README.md`,
+      `@@ -1,1 +1,1 @@`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const exit = runCli({
+      argv: ["not-a-sha", "2.1.0"],
+      readInput: () => text,
+      stderrWrite: (chunk) => stderr.push(chunk),
+    });
+    expect(exit).toBe(1);
+    expect(stderr.join("")).toContain("40-character lowercase hex string");
   });
 });

--- a/scripts/validate-self-pin-diff.test.ts
+++ b/scripts/validate-self-pin-diff.test.ts
@@ -221,6 +221,43 @@ describe("validateUnifiedDiff", () => {
   it("returns ok for an empty diff", () => {
     expect(validateUnifiedDiff("")).toEqual({ ok: true });
   });
+
+  it("accepts a SHA-only refresh whose removed side lacks a trailing newline", () => {
+    const hunk = [
+      `@@ -10,2 +10,2 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `\\ No newline at end of file`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a SHA-only refresh whose added side lacks a trailing newline", () => {
+    const hunk = [
+      `@@ -10,2 +10,2 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+      `\\ No newline at end of file`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a SHA-only refresh where both sides lack a trailing newline", () => {
+    const hunk = [
+      `@@ -10,2 +10,2 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `\\ No newline at end of file`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
+      `\\ No newline at end of file`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
 });
 
 describe("runCli", () => {

--- a/scripts/validate-self-pin-diff.test.ts
+++ b/scripts/validate-self-pin-diff.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { SELF_REPO } from "./self-repo.js";
 import { runCli, validateUnifiedDiff } from "./validate-self-pin-diff.js";
 
 const OLD_SHA = "af72a5bd7330432cee97137b04d04edebde80149";
@@ -20,8 +21,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -42,13 +43,13 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       step-a:`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}/prepare@${NEW_SHA} # v2.1.0`,
       `       with:`,
       `@@ -42,3 +42,3 @@`,
       `       step-b:`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action/review@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action/review@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}/review@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}/review@${NEW_SHA} # v2.1.0`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -59,8 +60,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0 # smuggled comment`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0 # smuggled comment`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -101,8 +102,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,4 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
       `+      env: { SECRET: leak }`,
       `       with:`,
     ].join("\n");
@@ -129,8 +130,8 @@ describe("validateUnifiedDiff", () => {
     const okHunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
       `       with:`,
     ].join("\n");
     const badHunk = [
@@ -155,8 +156,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action/review@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}/prepare@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}/review@${NEW_SHA} # v2.1.0`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -169,8 +170,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action/publish@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}/publish@${NEW_SHA} # v2.1.0`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -183,8 +184,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # malicious-text`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # malicious-text`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -197,8 +198,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA}`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}/prepare@${OLD_SHA}`,
+      `+      uses: ${SELF_REPO}/prepare@${NEW_SHA} # v2.1.0`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -209,8 +210,8 @@ describe("validateUnifiedDiff", () => {
     const hunk = [
       `@@ -10,3 +10,3 @@`,
       `       runs-on: ubuntu-latest`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0-rc.1`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0-rc.1`,
       `       with:`,
     ].join("\n");
     const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
@@ -230,8 +231,8 @@ describe("runCli", () => {
       `--- a/README.md`,
       `+++ b/README.md`,
       `@@ -1,1 +1,1 @@`,
-      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
-      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0`,
+      `-      uses: ${SELF_REPO}@${OLD_SHA} # v2.0.0`,
+      `+      uses: ${SELF_REPO}@${NEW_SHA} # v2.1.0`,
     ].join("\n");
     const exit = runCli({
       readInput: () => text,

--- a/scripts/validate-self-pin-diff.test.ts
+++ b/scripts/validate-self-pin-diff.test.ts
@@ -151,6 +151,72 @@ describe("validateUnifiedDiff", () => {
     expect(result.errors[0]).not.toContain(".github/workflows/codex-review.yaml:");
   });
 
+  it("rejects swapping the action subpath while bumping the SHA", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action/review@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("rejects converting a top-level reference to a subpath one", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action/publish@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("rejects a non-semver tag comment on the new line", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # malicious-text`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join("\n")).toContain("not a self-pin or sha-tag-note refresh");
+  });
+
+  it("accepts adding a v-prefixed tag comment to a previously bare self-pin", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${OLD_SHA}`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action/prepare@${NEW_SHA} # v2.1.0`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a pre-release tag comment (v2.1.0-rc.1)", () => {
+    const hunk = [
+      `@@ -10,3 +10,3 @@`,
+      `       runs-on: ubuntu-latest`,
+      `-      uses: milanhorvatovic/codex-ai-code-review-action@${OLD_SHA} # v2.0.0`,
+      `+      uses: milanhorvatovic/codex-ai-code-review-action@${NEW_SHA} # v2.1.0-rc.1`,
+      `       with:`,
+    ].join("\n");
+    const result = validateUnifiedDiff(buildDiff(".github/workflows/codex-review.yaml", hunk));
+    expect(result).toEqual({ ok: true });
+  });
+
   it("returns ok for an empty diff", () => {
     expect(validateUnifiedDiff("")).toEqual({ ok: true });
   });

--- a/scripts/validate-self-pin-diff.ts
+++ b/scripts/validate-self-pin-diff.ts
@@ -1,7 +1,7 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
+import { escapeRegex, SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
 
 // Capture group 1 (`owner + optional /sub`) is preserved verbatim in the masked output
 // so changes to the action subpath (e.g. `.../prepare@SHA` → `.../review@SHA`) produce
@@ -9,32 +9,89 @@ import { SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
 // tag comment are absorbed by the placeholder. The tag comment is restricted to a
 // semver-shaped vX.Y.Z[-PRE] form so an attacker can't smuggle arbitrary trailing text
 // past the masker by formatting it as a `#`-prefixed comment.
-const SELF_PIN_PATTERN = new RegExp(
+//
+// Loose patterns match any 40-hex SHA and any semver-shaped tag. They're used to mask
+// the removed (`-`) side of each diff pair, where the prior SHA / version is whatever
+// the file had before the refresh. Strict patterns (built per-call from
+// `expectedSha` + `expectedVersion`) are used to mask the added (`+`) side, so a refresh
+// PR that updates to the *wrong* SHA or *wrong* version doesn't mask cleanly and the
+// resulting masked-old vs masked-new comparison rejects it.
+const SELF_PIN_PATTERN_LOOSE = new RegExp(
   `(${SELF_REPO_REGEX_SOURCE}(?:\\/[\\w./-]+?)?)@[0-9a-f]{40}(?:[ \\t]*#[ \\t]*v\\d+\\.\\d+\\.\\d+(?:-[\\w.-]+)?)?`,
   "g",
 );
 
-const SHA_TAG_NOTE_PATTERN =
+const SHA_TAG_NOTE_PATTERN_LOOSE =
   /# SHA corresponds to tag v\d+\.\d+\.\d+(?:-[\w.-]+)? — update when adopting a new release\./g;
 
+const SELF_PIN_MASK = "<sha-and-tag>";
 const SHA_TAG_NOTE_MASK = "<sha-tag-note>";
+
+export type ValidateOptions = {
+  expectedSha?: string;
+  expectedVersion?: string;
+};
 
 export type ValidateResult = { ok: true } | { ok: false; errors: string[] };
 
-function maskLine(line: string): { masked: string; matched: boolean } {
+type Patterns = { selfPin: RegExp; note: RegExp };
+
+function buildStrictPatterns(sha: string, version: string): Patterns {
+  if (!/^[0-9a-f]{40}$/.test(sha)) {
+    throw new Error(
+      `expectedSha must be a 40-character lowercase hex string; got: ${sha}`,
+    );
+  }
+  if (!/^\d+\.\d+\.\d+(?:-[\w.-]+)?$/.test(version)) {
+    throw new Error(
+      `expectedVersion must be MAJOR.MINOR.PATCH[-PRE]; got: ${version}`,
+    );
+  }
+  const shaEsc = escapeRegex(sha);
+  const verEsc = escapeRegex(version);
+  return {
+    selfPin: new RegExp(
+      `(${SELF_REPO_REGEX_SOURCE}(?:\\/[\\w./-]+?)?)@${shaEsc}(?:[ \\t]*#[ \\t]*v${verEsc})?`,
+      "g",
+    ),
+    note: new RegExp(
+      `# SHA corresponds to tag v${verEsc} — update when adopting a new release\\.`,
+      "g",
+    ),
+  };
+}
+
+function maskLine(line: string, patterns: Patterns): { masked: string; matched: boolean } {
   let matched = false;
-  let masked = line.replace(SELF_PIN_PATTERN, (_match, ownerSub: string) => {
+  let masked = line.replace(patterns.selfPin, (_match, ownerSub: string) => {
     matched = true;
-    return `${ownerSub}@<sha-and-tag>`;
+    return `${ownerSub}@${SELF_PIN_MASK}`;
   });
-  masked = masked.replace(SHA_TAG_NOTE_PATTERN, () => {
+  masked = masked.replace(patterns.note, () => {
     matched = true;
     return SHA_TAG_NOTE_MASK;
   });
   return { masked, matched };
 }
 
-export function validateUnifiedDiff(text: string): ValidateResult {
+export function validateUnifiedDiff(text: string, opts: ValidateOptions = {}): ValidateResult {
+  if (
+    (opts.expectedSha === undefined) !== (opts.expectedVersion === undefined)
+  ) {
+    throw new Error(
+      "validateUnifiedDiff: pass both expectedSha and expectedVersion, or neither.",
+    );
+  }
+  const loosePatterns: Patterns = {
+    selfPin: SELF_PIN_PATTERN_LOOSE,
+    note: SHA_TAG_NOTE_PATTERN_LOOSE,
+  };
+  const strictPatterns =
+    opts.expectedSha !== undefined && opts.expectedVersion !== undefined
+      ? buildStrictPatterns(opts.expectedSha, opts.expectedVersion)
+      : undefined;
+  const oldPatterns = loosePatterns;
+  const newPatterns = strictPatterns ?? loosePatterns;
   const errors: string[] = [];
   const lines = text.split("\n");
   let inHunk = false;
@@ -104,8 +161,8 @@ export function validateUnifiedDiff(text: string): ValidateResult {
       for (let k = 0; k < minusBlock.length; k++) {
         const oldLine = minusBlock[k] ?? "";
         const newLine = plusBlock[k] ?? "";
-        const oldMask = maskLine(oldLine);
-        const newMask = maskLine(newLine);
+        const oldMask = maskLine(oldLine, oldPatterns);
+        const newMask = maskLine(newLine, newPatterns);
         if (oldMask.masked !== newMask.masked) {
           errors.push(
             `${currentPath}: changed line is not a self-pin or sha-tag-note refresh:\n  -${oldLine}\n  +${newLine}`,
@@ -132,6 +189,7 @@ export function validateUnifiedDiff(text: string): ValidateResult {
 }
 
 export type RunCliDeps = {
+  argv?: string[];
   readInput?: () => string;
   stderrWrite?: (chunk: string) => void;
 };
@@ -145,13 +203,38 @@ function defaultStderrWrite(chunk: string): void {
 }
 
 export function runCli(deps: RunCliDeps = {}): number {
+  const argv = deps.argv ?? process.argv.slice(2);
   const readInput = deps.readInput ?? defaultReadInput;
   const stderrWrite = deps.stderrWrite ?? defaultStderrWrite;
+
+  if (argv.length !== 0 && argv.length !== 2) {
+    stderrWrite(
+      [
+        "Usage:",
+        "  validate-self-pin-diff [<expected-sha> <expected-version>]",
+        "",
+        "Pass both arguments to enable strict validation (added self-pins and",
+        "SHA-tag notes must match the given SHA / version), or pass neither for",
+        "loose shape-only validation.",
+        "",
+      ].join("\n"),
+    );
+    return 1;
+  }
+
+  const expectedSha = argv[0];
+  const expectedVersion = argv[1];
   const text = readInput();
-  const result = validateUnifiedDiff(text);
-  if (result.ok) return 0;
-  for (const err of result.errors) stderrWrite(`${err}\n`);
-  return 1;
+  try {
+    const result = validateUnifiedDiff(text, { expectedSha, expectedVersion });
+    if (result.ok) return 0;
+    for (const err of result.errors) stderrWrite(`${err}\n`);
+    return 1;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderrWrite(`${message}\n`);
+    return 1;
+  }
 }
 
 function isInvokedDirectly(): boolean {

--- a/scripts/validate-self-pin-diff.ts
+++ b/scripts/validate-self-pin-diff.ts
@@ -1,22 +1,27 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+// Capture group 1 (`owner + optional /sub`) is preserved verbatim in the masked output
+// so changes to the action subpath (e.g. `.../prepare@SHA` → `.../review@SHA`) produce
+// different masked strings and fail validation. Only the SHA and the optional `# vSEMVER`
+// tag comment are absorbed by the placeholder. The tag comment is restricted to a
+// semver-shaped vX.Y.Z[-PRE] form so an attacker can't smuggle arbitrary trailing text
+// past the masker by formatting it as a `#`-prefixed comment.
 const SELF_PIN_PATTERN =
-  /milanhorvatovic\/codex-ai-code-review-action(?:\/[\w./-]+?)?@[0-9a-f]{40}(?:[ \t]*#[ \t]*[\w.+-]+)?/g;
+  /(milanhorvatovic\/codex-ai-code-review-action(?:\/[\w./-]+?)?)@[0-9a-f]{40}(?:[ \t]*#[ \t]*v\d+\.\d+\.\d+(?:-[\w.-]+)?)?/g;
 
 const SHA_TAG_NOTE_PATTERN =
   /# SHA corresponds to tag v\d+\.\d+\.\d+(?:-[\w.-]+)? — update when adopting a new release\./g;
 
-const SELF_PIN_MASK = "<self-pin>";
 const SHA_TAG_NOTE_MASK = "<sha-tag-note>";
 
 export type ValidateResult = { ok: true } | { ok: false; errors: string[] };
 
 function maskLine(line: string): { masked: string; matched: boolean } {
   let matched = false;
-  let masked = line.replace(SELF_PIN_PATTERN, () => {
+  let masked = line.replace(SELF_PIN_PATTERN, (_match, ownerSub: string) => {
     matched = true;
-    return SELF_PIN_MASK;
+    return `${ownerSub}@<sha-and-tag>`;
   });
   masked = masked.replace(SHA_TAG_NOTE_PATTERN, () => {
     matched = true;

--- a/scripts/validate-self-pin-diff.ts
+++ b/scripts/validate-self-pin-diff.ts
@@ -1,14 +1,18 @@
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { SELF_REPO_REGEX_SOURCE } from "./self-repo.js";
+
 // Capture group 1 (`owner + optional /sub`) is preserved verbatim in the masked output
 // so changes to the action subpath (e.g. `.../prepare@SHA` → `.../review@SHA`) produce
 // different masked strings and fail validation. Only the SHA and the optional `# vSEMVER`
 // tag comment are absorbed by the placeholder. The tag comment is restricted to a
 // semver-shaped vX.Y.Z[-PRE] form so an attacker can't smuggle arbitrary trailing text
 // past the masker by formatting it as a `#`-prefixed comment.
-const SELF_PIN_PATTERN =
-  /(milanhorvatovic\/codex-ai-code-review-action(?:\/[\w./-]+?)?)@[0-9a-f]{40}(?:[ \t]*#[ \t]*v\d+\.\d+\.\d+(?:-[\w.-]+)?)?/g;
+const SELF_PIN_PATTERN = new RegExp(
+  `(${SELF_REPO_REGEX_SOURCE}(?:\\/[\\w./-]+?)?)@[0-9a-f]{40}(?:[ \\t]*#[ \\t]*v\\d+\\.\\d+\\.\\d+(?:-[\\w.-]+)?)?`,
+  "g",
+);
 
 const SHA_TAG_NOTE_PATTERN =
   /# SHA corresponds to tag v\d+\.\d+\.\d+(?:-[\w.-]+)? — update when adopting a new release\./g;

--- a/scripts/validate-self-pin-diff.ts
+++ b/scripts/validate-self-pin-diff.ts
@@ -1,0 +1,150 @@
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const SELF_PIN_PATTERN =
+  /milanhorvatovic\/codex-ai-code-review-action(?:\/[\w./-]+?)?@[0-9a-f]{40}(?:[ \t]*#[ \t]*[\w.+-]+)?/g;
+
+const SHA_TAG_NOTE_PATTERN =
+  /# SHA corresponds to tag v\d+\.\d+\.\d+(?:-[\w.-]+)? — update when adopting a new release\./g;
+
+const SELF_PIN_MASK = "<self-pin>";
+const SHA_TAG_NOTE_MASK = "<sha-tag-note>";
+
+export type ValidateResult = { ok: true } | { ok: false; errors: string[] };
+
+function maskLine(line: string): { masked: string; matched: boolean } {
+  let matched = false;
+  let masked = line.replace(SELF_PIN_PATTERN, () => {
+    matched = true;
+    return SELF_PIN_MASK;
+  });
+  masked = masked.replace(SHA_TAG_NOTE_PATTERN, () => {
+    matched = true;
+    return SHA_TAG_NOTE_MASK;
+  });
+  return { masked, matched };
+}
+
+export function validateUnifiedDiff(text: string): ValidateResult {
+  const errors: string[] = [];
+  const lines = text.split("\n");
+  let inHunk = false;
+  let currentPath = "<unknown>";
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line === undefined) break;
+    if (line.startsWith("diff --git ")) {
+      const match = /^diff --git a\/(.+?) b\//.exec(line);
+      currentPath = match?.[1] ?? "<unknown>";
+      inHunk = false;
+      i++;
+      continue;
+    }
+    if (line.startsWith("@@")) {
+      inHunk = true;
+      i++;
+      continue;
+    }
+    if (
+      line.startsWith("index ") ||
+      line.startsWith("--- ") ||
+      line.startsWith("+++ ") ||
+      line.startsWith("\\")
+    ) {
+      i++;
+      continue;
+    }
+    if (!inHunk) {
+      i++;
+      continue;
+    }
+    if (line.startsWith("-")) {
+      const minusBlock: string[] = [];
+      while (i < lines.length) {
+        const next = lines[i];
+        if (next === undefined) break;
+        if (!next.startsWith("-") || next.startsWith("--- ")) break;
+        minusBlock.push(next.slice(1));
+        i++;
+      }
+      const plusBlock: string[] = [];
+      while (i < lines.length) {
+        const next = lines[i];
+        if (next === undefined) break;
+        if (!next.startsWith("+") || next.startsWith("+++ ")) break;
+        plusBlock.push(next.slice(1));
+        i++;
+      }
+      if (minusBlock.length !== plusBlock.length) {
+        errors.push(
+          `${currentPath}: unbalanced hunk (${minusBlock.length} removed, ${plusBlock.length} added)`,
+        );
+        continue;
+      }
+      for (let k = 0; k < minusBlock.length; k++) {
+        const oldLine = minusBlock[k] ?? "";
+        const newLine = plusBlock[k] ?? "";
+        const oldMask = maskLine(oldLine);
+        const newMask = maskLine(newLine);
+        if (oldMask.masked !== newMask.masked) {
+          errors.push(
+            `${currentPath}: changed line is not a self-pin or sha-tag-note refresh:\n  -${oldLine}\n  +${newLine}`,
+          );
+          continue;
+        }
+        if (!oldMask.matched && !newMask.matched) {
+          errors.push(
+            `${currentPath}: changed line matches no expected pattern:\n  -${oldLine}\n  +${newLine}`,
+          );
+        }
+      }
+      continue;
+    }
+    if (line.startsWith("+")) {
+      errors.push(`${currentPath}: pure addition is not a SHA-only refresh:\n  +${line.slice(1)}`);
+      i++;
+      continue;
+    }
+    i++;
+  }
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true };
+}
+
+export type RunCliDeps = {
+  readInput?: () => string;
+  stderrWrite?: (chunk: string) => void;
+};
+
+function defaultReadInput(): string {
+  return readFileSync(0, "utf-8");
+}
+
+function defaultStderrWrite(chunk: string): void {
+  process.stderr.write(chunk);
+}
+
+export function runCli(deps: RunCliDeps = {}): number {
+  const readInput = deps.readInput ?? defaultReadInput;
+  const stderrWrite = deps.stderrWrite ?? defaultStderrWrite;
+  const text = readInput();
+  const result = validateUnifiedDiff(text);
+  if (result.ok) return 0;
+  for (const err of result.errors) stderrWrite(`${err}\n`);
+  return 1;
+}
+
+function isInvokedDirectly(): boolean {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isInvokedDirectly()) {
+  process.exit(runCli());
+}

--- a/scripts/validate-self-pin-diff.ts
+++ b/scripts/validate-self-pin-diff.ts
@@ -73,6 +73,12 @@ export function validateUnifiedDiff(text: string): ValidateResult {
       while (i < lines.length) {
         const next = lines[i];
         if (next === undefined) break;
+        // Skip `\ No newline at end of file` markers so an EOF SHA refresh whose removed
+        // or added side lacks a trailing newline still pairs minus/plus blocks 1:1.
+        if (next.startsWith("\\")) {
+          i++;
+          continue;
+        }
         if (!next.startsWith("-") || next.startsWith("--- ")) break;
         minusBlock.push(next.slice(1));
         i++;
@@ -81,6 +87,10 @@ export function validateUnifiedDiff(text: string): ValidateResult {
       while (i < lines.length) {
         const next = lines[i];
         if (next === undefined) break;
+        if (next.startsWith("\\")) {
+          i++;
+          continue;
+        }
         if (!next.startsWith("+") || next.startsWith("+++ ")) break;
         plusBlock.push(next.slice(1));
         i++;

--- a/scripts/validate-self-pin-diff.ts
+++ b/scripts/validate-self-pin-diff.ts
@@ -96,19 +96,68 @@ export function validateUnifiedDiff(text: string, opts: ValidateOptions = {}): V
   const lines = text.split("\n");
   let inHunk = false;
   let currentPath = "<unknown>";
+  let inDiffSection = false;
+  let sectionHasHunk = false;
   let i = 0;
+
+  const flushSectionWithoutHunk = () => {
+    if (inDiffSection && !sectionHasHunk) {
+      errors.push(
+        `${currentPath}: diff section has no hunks (binary patch or header-only change is not a SHA-only refresh)`,
+      );
+    }
+  };
+
   while (i < lines.length) {
     const line = lines[i];
     if (line === undefined) break;
     if (line.startsWith("diff --git ")) {
+      flushSectionWithoutHunk();
       const match = /^diff --git a\/(.+?) b\//.exec(line);
       currentPath = match?.[1] ?? "<unknown>";
       inHunk = false;
+      inDiffSection = true;
+      sectionHasHunk = false;
       i++;
       continue;
     }
     if (line.startsWith("@@")) {
       inHunk = true;
+      sectionHasHunk = true;
+      i++;
+      continue;
+    }
+    // Reject any header indicating that the diff section carries something other than a
+    // line-level content edit: file-mode changes (which alter executability of a
+    // workflow file), file creations / deletions, renames / copies, and binary patches.
+    if (
+      line.startsWith("old mode ") ||
+      line.startsWith("new mode ") ||
+      line.startsWith("new file mode ") ||
+      line.startsWith("deleted file mode ")
+    ) {
+      errors.push(
+        `${currentPath}: file mode change is not a SHA-only refresh: ${line}`,
+      );
+      i++;
+      continue;
+    }
+    if (
+      line.startsWith("rename from ") ||
+      line.startsWith("rename to ") ||
+      line.startsWith("copy from ") ||
+      line.startsWith("copy to ")
+    ) {
+      errors.push(
+        `${currentPath}: file rename/copy is not a SHA-only refresh: ${line}`,
+      );
+      i++;
+      continue;
+    }
+    if (line.startsWith("Binary files ") || line.startsWith("GIT binary patch")) {
+      errors.push(
+        `${currentPath}: binary patch is not a SHA-only refresh: ${line}`,
+      );
       i++;
       continue;
     }
@@ -116,6 +165,8 @@ export function validateUnifiedDiff(text: string, opts: ValidateOptions = {}): V
       line.startsWith("index ") ||
       line.startsWith("--- ") ||
       line.startsWith("+++ ") ||
+      line.startsWith("similarity index ") ||
+      line.startsWith("dissimilarity index ") ||
       line.startsWith("\\")
     ) {
       i++;
@@ -184,6 +235,7 @@ export function validateUnifiedDiff(text: string, opts: ValidateOptions = {}): V
     }
     i++;
   }
+  flushSectionWithoutHunk();
   if (errors.length > 0) return { ok: false, errors };
   return { ok: true };
 }

--- a/scripts/verify-doc-pins.ts
+++ b/scripts/verify-doc-pins.ts
@@ -2,6 +2,8 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { SELF_REPO } from "./self-repo.js";
+
 export type CanonicalLocation = { path: string; line: number };
 export type CanonicalEntry = { sha: string; tag?: string; location: CanonicalLocation };
 export type CanonicalMap = Map<string, CanonicalEntry>;
@@ -29,7 +31,7 @@ export type YamlDisagreement = {
 
 export type Drift = DocMismatch | YamlDisagreement;
 
-export const SELF_REPO = "milanhorvatovic/codex-ai-code-review-action";
+export { SELF_REPO };
 
 export const PIN_PATTERN =
   /(?<owner>[\w.-]+)\/(?<repo>[\w.-]+)(?:\/(?<sub>[\w./-]+?))?@(?<sha>[0-9a-f]{40})(?:[ \t]*#[ \t]*(?<tag>[\w.+-]+))?/g;


### PR DESCRIPTION
## Summary

After every final tag push, `release.yaml` opens a deterministic self-pin refresh PR (e.g. #146 for v2.1.0) that bumps the action's own SHA pin in `README.md` and `.github/workflows/codex-review.yaml`. The diff is mechanical: only the 40-hex SHA + tag comment change; CI (`verify-doc-pins`, `verify-dist`, `test`, lint, typecheck) already catches any regression. The manual approve + merge step adds no review signal — it's pure toil per release cycle, and it gates the post-tag step of `docs/release-gate.md` ("self-pin refresh PR merged") so the maintainer can't ship the evidence zip until it lands.

This PR moves that step into `release.yaml` itself by adding three steps after the existing `Open self-pin refresh PR` block:

1. **Resolve self-pin refresh PR number** — looks up the open PR for branch `docs/refresh-self-pins-v${VERSION_NUM}`, filtering via `select(.isCrossRepository == false)` so a fork PR with the same branch name (the branch name is deterministic per release) is silently ignored. No-ops when no matching PR exists. The step is fail-open on transient `gh` outages — warns, emits an empty `number` output, and exits 0 rather than aborting the release job.

2. **Auto-approve self-pin refresh PR** — posts a PAT-driven approval using `CODEOWNER_APPROVER_TOKEN`. The PAT belongs to a code-owner, so the approval satisfies the protected-main CODEOWNER review requirement. Three layered safety checks gate the approval; failure on any of them sets `guard_ok=false` on `$GITHUB_OUTPUT`:
   - **File-set whitelist** — refuses if the diff touches anything outside `README.md` and `.github/workflows/codex-review.yaml`.
   - **Strict unified-diff content check** — pipes `gh pr diff "${PR}"` through `scripts/validate-self-pin-diff.ts <TAG_SHA> <VERSION_NUM>`. Every changed line must be a self-pin SHA bump or a `# SHA corresponds to tag v…` note bump; the *added* (`+`) side must reference exactly the just-tagged commit and `v${VERSION_NUM}` (not just any 40-hex SHA / any semver tag). The validator also rejects file-mode changes, renames/copies, binary patches, header-only diff sections, and `EOF`-newline-marker edge cases that previously slipped through structurally.
   - **Identity precondition** — the two checks above can't run without `CODEOWNER_APPROVER_TOKEN`, so a missing PAT also flips `guard_ok=false`.

3. **Enable auto-merge on self-pin refresh PR** — `gh pr merge --auto --squash --delete-branch`, gated on `steps.approve-refresh.outputs.guard_ok != 'false'`. GitHub's auto-merge primitive squash-merges as soon as required checks pass and an APPROVED review is recorded.

## Failure-mode taxonomy

Two distinct classes of failure are routed differently in the approve step:

- **Safety-check failure** → `guard_ok=false` → auto-merge refused. Covers: missing PAT, file-set query failure (`gh pr diff --name-only`), file-set whitelist trip, content-diff fetch failure (`gh pr diff`), and content-check trip. The maintainer reviews the diff and merges by hand.
- **Approval-post transport failure** → `guard_ok` left unset → auto-merge still arms. Covers: `gh pr review --approve` errored *after* both safety checks already completed cleanly. A manual code-owner approval is safe to substitute, since the diff has already been validated; GitHub then merges on the manual approval.

The resolve step has its own fail-open behavior on `gh pr list` outages (empty `number` output → downstream steps no-op).

## Why this is preferable to a separate workflow

- One workflow owns the refresh lifecycle: tag → floating-tag move → refresh branch push → refresh PR open → approve → enqueue merge. Reading `release.yaml` top to bottom shows the whole story.
- No `pull_request` event coupling — uses GitHub's auto-merge primitive instead of polling on PR events from a separate workflow.
- Easier to disable: comment out the three steps.

## Trust-boundary implications

Labeled `trust-boundary`. The change does not alter data destinations, telemetry, permissions, artifact contents, sandboxing, or secret scoping. It **does** change maintainer-side review obligations:

- The CODEOWNER review on the refresh PR class moves from a manual click to a PAT-driven auto-approval.
- The PAT (`CODEOWNER_APPROVER_TOKEN`) belongs to a code-owner, so the GitHub-side CODEOWNER requirement is still met. The change is in *who* clicks approve, not *whether* approval is required.
- The trust point is the layered safety checks taken together: cross-repo filter (rejects fork PRs that share the deterministic branch name), file-set whitelist (rejects PRs that touch anything but the two known targets), strict content check (rejects PRs whose changed lines aren't SHA-pin / tag-note bumps to the exact just-tagged values), and structural diff guards (mode changes, renames, binary patches, no-hunk sections).
- `release: skip` because workflow-only change with no behavior change for adopters — the refresh PR class is internal infra. Per the gate doc, either label on a `release: skip` PR does not by itself trigger a CHANGELOG callout requirement, so no CHANGELOG entry is needed.

### What re-reviewers should check

- `select(.isCrossRepository == false)` in the resolver step — a fork PR named `docs/refresh-self-pins-vX.Y.Z` opened against this repo must not be selectable here.
- `scripts/validate-self-pin-diff.ts` strict mode — when invoked with `<expected-sha> <expected-version>`, the added-side mask only matches `@<expected-sha>` followed by an optional `# v<expected-version>`. A regression that refreshes to any other 40-hex SHA or any other semver tag fails the masked-old vs masked-new comparison.
- The structural rejections in the validator — file-mode headers (`old mode`/`new mode`/`new file mode`/`deleted file mode`), rename/copy headers, `Binary files … differ`, `GIT binary patch`, and any `diff --git` section that lacks a `@@` hunk all surface as errors and trip the guard.
- The auto-approve step writes `guard_ok=false` on every unverified safety-check path (missing PAT, file-set query failure, file-set whitelist trip, content-diff fetch failure, content-check trip); the merge step's condition includes `steps.approve-refresh.outputs.guard_ok != 'false'`. Only an approval-post transport failure leaves `guard_ok` unset.
- Both steps gate on `!contains(github.ref_name, '-')`, matching the existing self-pin refresh step's RC skip.
- The `approve` step uses `CODEOWNER_APPROVER_TOKEN` (PAT, code-owner identity); the `merge` step uses `steps.app-token.outputs.token` (App identity) — the split is required because GitHub bars an App from approving its own PR.
- `SELF_REPO` is now centralized in `scripts/self-repo.ts` (a fork or rename updates one line; `escapeRegex` handles every regex metacharacter so any valid repo identifier works as-is) and consumed by `refresh-self-pins.ts`, `validate-self-pin-diff.ts`, `verify-doc-pins.ts`, and `prepare-release.ts`.

## Prerequisites

One-time setup before this PR is merged:

1. **Allow auto-merge.** Repo Settings → General → Pull Requests → Allow auto-merge must be enabled. Already on if `dependabot-auto-merge.yaml` is functional.
2. **Mirror the PAT.** `CODEOWNER_APPROVER_TOKEN` currently lives in the Dependabot secret store. Copy the same value to Settings → Secrets and variables → **Actions** → `CODEOWNER_APPROVER_TOKEN` (the Dependabot and Actions stores are separately readable; release.yaml triggers on `push: tags`, not on Dependabot events, so it reads from the Actions store).

Without (2), the approve step warns, writes `guard_ok=false`, and the refresh PR waits for a manual code-owner review + merge — strictly more conservative than the pre-PR behavior (no regression).

## Test plan

The live release flow (resolve → auto-approve → auto-merge) only fires on `release.yaml`'s tag-push trigger and is short-circuited on pre-release tags via `!contains(github.ref_name, '-')`, so the happy path can't be exercised on this PR. Each new safety layer is covered by unit tests that *can* be exercised pre-merge, and the post-merge plan validates the live wiring on the next final release.

### Pre-merge (run locally)

- [x] `npm run typecheck && npm run lint && npm run test && npm run verify:prose-style && npm run verify:doc-pins` — clean (666/666 tests).
- [x] `scripts/validate-self-pin-diff.test.ts` exercises every safety layer: loose-mode shape check, strict-mode (`expectedSha` + `expectedVersion`) target check, subpath-swap rejection, top-level-to-subpath conversion rejection, non-semver-tag rejection, EOF "no newline at end of file" marker handling, file-mode / rename / copy / binary-patch / header-only-section rejection, and the CLI's argv shapes (zero args = loose; two args = strict; one arg = usage error).
- [x] `scripts/self-repo.test.ts` exercises `escapeRegex` against every JS regex metacharacter (`. * + ? ^ $ ( ) [ ] { } | \\ /`), plus the wildcard-avoidance case for `.` and the backslash case for `\\`.

### Pre-merge (one-time repo configuration; see "Prerequisites" above)

- [x] Repo Settings → General → Pull Requests → Allow auto-merge is enabled (`gh api repos/… --jq .allow_auto_merge` → `true`).
- [x] `CODEOWNER_APPROVER_TOKEN` is mirrored from the Dependabot secret store into Settings → Secrets and variables → **Actions** (`gh secret list --app actions` shows it alongside `RELEASE_APP_PRIVATE_KEY` and `AUTOMATION_PRIVATE_KEY`). If it had been skipped, the next release would write `guard_ok=false`, refuse auto-merge, and the refresh PR would wait for a manual code-owner approval + merge — strictly more conservative than today's manual flow, no regression.

### Post-merge happy path (next final release tag after this PR lands)

- [ ] Resolve step emits a non-empty `number` output and the log line names the same-repo, main-base refresh PR.
- [ ] Auto-approve step posts an APPROVED review under the `CODEOWNER_APPROVER_TOKEN` identity; the review body records the enforced `${TAG_SHA}` and `v${VERSION_NUM}`.
- [ ] Auto-merge is armed (`gh pr merge --auto --squash --delete-branch`) and `steps.approve-refresh.outputs.guard_ok` is empty (not `'false'`).
- [ ] The refresh PR squash-merges automatically once CI is green.

### Post-merge negative paths (controlled regressions on a scratch branch)

Each path produces a deliberately "bad" refresh PR and verifies that `guard_ok=false` is written, auto-merge is refused, and the PR is left open for manual review. Boxes ticked below are backed by unit-test or code-inspection coverage in this branch; a scratch-branch end-to-end re-exercise after merge is still encouraged but no longer load-bearing.

- [x] **File-set whitelist trip** — refresh PR diff includes a file outside `README.md` / `.github/workflows/codex-review.yaml`. (Workflow regex `grep -Ev '^(README\.md|\.github/workflows/codex-review\.yaml)$'` writes `guard_ok=false` on a non-empty result.)
- [x] **Content-shape rejection** — refresh PR contains a non-SHA edit inside a whitelisted file (e.g. swapping `/prepare` to `/review`, or smuggling a `# malicious-text` tag in place of `# vX.Y.Z`). (Covered by `validate-self-pin-diff.test.ts` subpath-swap + non-semver-tag tests.)
- [x] **Wrong-target SHA rejection** — refresh PR's added self-pins reference a 40-hex SHA that is not the just-tagged commit; strict-mode content check rejects. (Covered by `validate-self-pin-diff.test.ts` strict-mode wrong-SHA tests.)
- [x] **Wrong-target version rejection** — refresh PR's added tag comment is not `v${VERSION_NUM}` (or the added SHA-tag note version disagrees); strict-mode content check rejects. (Covered by `validate-self-pin-diff.test.ts` strict-mode wrong-tag and wrong-note tests.)
- [x] **Structural rejection** — refresh PR contains a file-mode change (`old mode`/`new mode`/`new file mode`/`deleted file mode`), a rename/copy, a binary patch (`Binary files … differ` / `GIT binary patch`), or a `diff --git` section with no `@@` hunk. (Covered by `validate-self-pin-diff.test.ts` mode-change, new-file, rename, `Binary files differ`, `GIT binary patch`, and header-only-section tests.)
- [x] **EOF newline-marker happy path** — a SHA-only refresh at the last line of a file with no trailing newline (any of: removed side, added side, both sides bracketed by `\ No newline at end of file`) validates as `ok: true` rather than tripping "unbalanced hunk". (Covered by `validate-self-pin-diff.test.ts` three EOF-marker tests.)
- [x] **Cross-repo rejection** — a fork PR named `docs/refresh-self-pins-vX.Y.Z` opened concurrently is ignored by both the Open-step existing-PR check (it still creates the base-repo PR) and the Resolve step (it emits an empty `number`). (Both `gh pr list` calls in `release.yaml` use `select(.isCrossRepository == false)`.)
- [x] **Wrong-base rejection** — a same-repo PR from `docs/refresh-self-pins-vX.Y.Z` targeting a non-main base is ignored by both the Open step and the Resolve step. (Both `gh pr list` calls in `release.yaml` use `--base main`.)

### Post-merge transport-failure routing

The approve step routes safety-check failures and approval-post failures differently. Each path's branch is inspectable in `release.yaml` today; live mid-run simulation is encouraged but not load-bearing.

- [x] **Safety-check transport failure** — simulate a `gh pr diff --name-only` or `gh pr diff` API failure. Approve step writes `guard_ok=false`; merge step refuses to arm auto-merge; PR waits for manual review + merge. (Both `gh pr diff` call sites write `guard_ok=false` on a non-zero exit; merge step's `if` includes `steps.approve-refresh.outputs.guard_ok != 'false'`.)
- [x] **Approval-post transport failure** — let both safety checks complete cleanly, then fail `gh pr review --approve` (e.g. revoke the PAT after the diff fetches). Approve step exits 0 without setting `guard_ok`; merge step still arms auto-merge; a later manual code-owner approval fires the merge. (The `gh pr review --approve` failure branch emits a `::warning::` and `exit 0` without writing `guard_ok`; merge step's `if` therefore stays satisfied.)
- [x] **Resolve-step transport failure** — `gh pr list` outage emits an empty `number` output; downstream steps no-op for that release; the release tag is unaffected. (Resolve step's `gh pr list` failure branch writes `number=` to `$GITHUB_OUTPUT`; both downstream steps gate on `steps.refresh-pr.outputs.number != ''`.)

## Related

- #146 — the v2.1.0 self-pin refresh PR that motivated this work; merged manually before this PR, this change applies to subsequent releases.
- Memory rule `[[feedback_unified_action_pins]]` — every third-party Action must be pinned to the same SHA + tag everywhere; this PR keeps the action's own SHA in lockstep with the just-cut tag without maintainer toil.

