### PR TITLE
ci(release): pass --title explicitly to gh release create so the release header uses the tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,16 @@ jobs:
             case "${GITHUB_REF_NAME}" in
               *-*) PRERELEASE_FLAG="--prerelease" ;;
             esac
-            gh release create "$GITHUB_REF_NAME" --notes-file "$NOTES_FILE" $PRERELEASE_FLAG
+            # `--title "$GITHUB_REF_NAME"` is explicit so GitHub's web UI does not fall back to
+            # the tagged commit's subject when rendering the release header. The squash-merge
+            # commit on `main` carries its own subject (today written by the maintainer at
+            # merge time); leaving `--title` unset made GitHub display that subject as the
+            # release name, which read awkwardly when the subject still carried the legacy
+            # `release: v…` prefix.
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file "$NOTES_FILE" \
+              $PRERELEASE_FLAG
           fi
 
       - name: Update major version tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,11 +251,11 @@ Use this path when `prepare-release.yaml` is broken or an urgent hotfix needs cu
 >
 > The release workflow runs on the tag push and creates the GitHub Release from the same `CHANGELOG.md` section.
 >
-> If the workflow is unavailable and you need to create the release by hand, extract the notes and pass them explicitly — do **not** use `--generate-notes`, which bypasses the CHANGELOG:
+> If the workflow is unavailable and you need to create the release by hand, extract the notes and pass them explicitly — do **not** use `--generate-notes`, which bypasses the CHANGELOG. Pass `--title vx.y.z` explicitly so the release header is pinned to the tag; without it, GitHub's web UI falls back to the tagged commit's subject for the release name, which couples the release page heading to whatever the squash-merge commit subject ended up being.
 >
 > ```bash
 > npx tsx scripts/extract-changelog-section.ts x.y.z > /tmp/notes.md
-> gh release create vx.y.z --notes-file /tmp/notes.md
+> gh release create vx.y.z --title vx.y.z --notes-file /tmp/notes.md
 > ```
 
 ## License


### PR DESCRIPTION
## Summary

The v2.1.0 release page (https://github.com/milanhorvatovic/codex-ai-code-review-action/releases/tag/v2.1.0) rendered as `release: v2.1.0` even though the tag is `v2.1.0` and the release's `name` field was `null`. Root cause: `release.yaml` called `gh release create "$GITHUB_REF_NAME"` without `--title`, leaving `name: null`. With an empty release name, GitHub's web UI falls back to the **tagged commit's subject** — and the squash-merge commit for v2.1.0 was authored with the legacy `release: v2.1.0` subject, so the header inherited that.

## What this PR changes

Pass `--title "$GITHUB_REF_NAME"` to `gh release create` so the release header is always the tag string, regardless of what the squash-merge commit subject ends up being. This decouples the release page heading from maintainer commit-subject typing.

## Past releases

Already fixed in place via `gh release edit <tag> --title <tag>` (no PR needed for that — it's a one-shot metadata update on the API). The releases now show:

- v2.1.0 → `name: "v2.1.0"`
- v2.1.0-rc.2 → `name: "v2.1.0-rc.2"`
- v2.1.0-rc.1 → `name: "v2.1.0-rc.1"`

v2.0.0 and v1.x already had explicit names; not touched.

## Why this is independent of #148

#148 drops the `release: ` prefix from the **release-prep commit subject and PR title**. That helps the *PR list* and the *squash-merge commit on main*. But the release header on GitHub Releases falls back to the commit subject only when the release `name` is unset — so even after #148, a future maintainer who types `chore: bump to v2.2.0` as their squash subject would still see "chore: bump to v2.2.0" as the release header. This PR is the durable fix at the release-creation step.

## Test plan

- [x] `actionlint` clean.
- [ ] Live validation on next final release: confirm `gh release view <tag>` returns `title: <tag>` (matching the tag name) right after `release.yaml` runs.
- [ ] Confirm the web UI release page header reads `v<X.Y.Z>` not `<commit-subject>`.

## Notes

`release: skip` because workflow-only change with no behavior change for adopters. Pairs naturally with #148 but is independently valuable.